### PR TITLE
Field plot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(CPET VERSION 0.2.1)
+project(CPET VERSION 0.3.0)
 if( NOT CMAKE_BUILD_TYPE )
   message("Setting to CMAKE_BUILD_TYPE to Release")
   set(CMAKE_BUILD_TYPE Release)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ On Linux, gnuplot should be in your package manager repo's already. For example 
 
 ## Installation
 ### Download Binaries
-Binaries (version 0.2.1) are available for [Linux](https://github.com/matthew-hennefarth/CPET/releases/download/v0.2.1/cpet_Linux-x86_64) (x86_64 architecture) and [MacOSX](https://github.com/matthew-hennefarth/CPET/releases/download/v0.2.1/cpet_MacOSX-ARM64) (ARM 64, 'Apple Silicon'). Linux binaries are fully statically linked; however, MacOS binaries are still dynamically linked to system libraries. If you receive an error such as 
+Binaries (version 0.3.0) are available for [Linux](https://github.com/matthew-hennefarth/CPET/releases/download/v0.3.0/cpet_Linux-x86_64) (x86_64 architecture) and [MacOSX](https://github.com/matthew-hennefarth/CPET/releases/download/v0.3.0/cpet_MacOSX-ARM64) (ARM 64, 'Apple Silicon'). Linux binaries are fully statically linked; however, MacOS binaries are still dynamically linked to system libraries. If you receive an error such as 
 
     /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.26' not found
 

--- a/include/AtomID.h
+++ b/include/AtomID.h
@@ -54,8 +54,7 @@ class AtomID {
   inline AtomID& operator=(const AtomID&) = default;
   inline AtomID& operator=(AtomID&&) = default;
 
-  template <typename S1,
-            typename = std::enable_if_t<std::is_convertible_v<S1, std::string>>>
+  template <typename S1>
   inline AtomID& operator=(S1&& rhs) {
     setID(std::forward<S1>(rhs));
     isConstant_ = false;

--- a/include/AtomID.h
+++ b/include/AtomID.h
@@ -39,20 +39,21 @@ class AtomID {
     }
   }
 
-  template<typename S1>
+  template<typename S1, typename = std::enable_if_t<std::is_convertible_v<S1, std::string>>>
   explicit inline AtomID(S1&& other_id) : id_(std::forward<S1>(other_id)) {
     if (!validID()) {
       throw cpet::value_error("Invalid atom ID: " + id_);
     }
   }
 
+  explicit inline AtomID(AtomID&&) = default;
+
   inline AtomID(const AtomID&) = default;
-  inline AtomID(AtomID&&) = default;
   inline ~AtomID() = default;
   inline AtomID& operator=(const AtomID&) = default;
   inline AtomID& operator=(AtomID&&) = default;
 
-  template<typename S1>
+  template<typename S1, typename = std::enable_if_t<std::is_convertible_v<S1, std::string>>>
   inline AtomID& operator=(S1&& rhs) {
     setID(std::forward<S1>(rhs));
     isConstant_ = false;

--- a/include/AtomID.h
+++ b/include/AtomID.h
@@ -39,7 +39,8 @@ class AtomID {
     }
   }
 
-  template<typename S1, typename = std::enable_if_t<std::is_convertible_v<S1, std::string>>>
+  template <typename S1,
+            typename = std::enable_if_t<std::is_convertible_v<S1, std::string>>>
   explicit inline AtomID(S1&& other_id) : id_(std::forward<S1>(other_id)) {
     if (!validID()) {
       throw cpet::value_error("Invalid atom ID: " + id_);
@@ -53,7 +54,8 @@ class AtomID {
   inline AtomID& operator=(const AtomID&) = default;
   inline AtomID& operator=(AtomID&&) = default;
 
-  template<typename S1, typename = std::enable_if_t<std::is_convertible_v<S1, std::string>>>
+  template <typename S1,
+            typename = std::enable_if_t<std::is_convertible_v<S1, std::string>>>
   inline AtomID& operator=(S1&& rhs) {
     setID(std::forward<S1>(rhs));
     isConstant_ = false;
@@ -78,7 +80,8 @@ class AtomID {
            (isVector(atomid) || util::isDouble(splitID[1]));
   }
 
-  [[nodiscard]] inline bool operator==(const std::string_view rhs) const noexcept {
+  [[nodiscard]] inline bool operator==(
+      const std::string_view rhs) const noexcept {
     return (id_ == rhs);
   }
 
@@ -90,7 +93,8 @@ class AtomID {
     return (id_ == rhs.id_);
   }
 
-  [[nodiscard]] inline bool operator!=(const std::string_view rhs) const noexcept {
+  [[nodiscard]] inline bool operator!=(
+      const std::string_view rhs) const noexcept {
     return !(*this == rhs);
   }
 
@@ -100,7 +104,7 @@ class AtomID {
 
   [[nodiscard]] inline const std::string& ID() const noexcept { return id_; }
 
-  template<typename S1>
+  template <typename S1>
   inline void setID(S1&& newID) {
     if (validID(std::forward<S1>(newID))) {
       id_ = std::forward<S1>(newID);
@@ -110,13 +114,17 @@ class AtomID {
     }
   }
 
-  [[nodiscard]] static inline AtomID generateID(const std::string_view pdbLine) {
+  [[nodiscard]] static inline AtomID generateID(
+      const std::string_view pdbLine) {
     if (pdbLine.size() < MIN_PDB_LINE_LENGTH) {
-      throw cpet::value_error("pdb line to short: " + static_cast<std::string>(pdbLine));
+      throw cpet::value_error("pdb line to short: " +
+                              static_cast<std::string>(pdbLine));
     }
 
     std::stringstream result_stream;
-    result_stream << pdbLine.substr(PDB_CHAIN_START, PDB_CHAIN_WIDTH) << ':' << pdbLine.substr(PDB_RESNUM_START, PDB_RESNUM_WIDTH) << ':' << pdbLine.substr(PDB_ATOMID_START, PDB_ATOMID_WIDTH);
+    result_stream << pdbLine.substr(PDB_CHAIN_START, PDB_CHAIN_WIDTH) << ':'
+                  << pdbLine.substr(PDB_RESNUM_START, PDB_RESNUM_WIDTH) << ':'
+                  << pdbLine.substr(PDB_ATOMID_START, PDB_ATOMID_WIDTH);
     auto result = result_stream.str();
     result.erase(remove(begin(result), end(result), ' '), end(result));
     return AtomID(result);

--- a/include/AtomID.h
+++ b/include/AtomID.h
@@ -32,14 +32,14 @@ class AtomID {
  public:
   enum class Constants { origin, e1, e2 };
 
-  explicit inline AtomID(Constants other_id)
+  explicit inline AtomID(const Constants other_id)
       : isConstant_(true), id_(decodeConstant_(other_id)) {
     if (!validID()) {
       throw cpet::value_error("Invalid atom id: " + id_);
     }
   }
 
-  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  template<typename S1>
   explicit inline AtomID(S1&& other_id) : id_(std::forward<S1>(other_id)) {
     if (!validID()) {
       throw cpet::value_error("Invalid atom ID: " + id_);
@@ -47,17 +47,14 @@ class AtomID {
   }
 
   inline AtomID(const AtomID&) = default;
-
   inline AtomID(AtomID&&) = default;
-
   inline ~AtomID() = default;
-
   inline AtomID& operator=(const AtomID&) = default;
-
   inline AtomID& operator=(AtomID&&) = default;
 
-  inline AtomID& operator=(const std::string& rhs) {
-    setID(rhs);
+  template<typename S1>
+  inline AtomID& operator=(S1&& rhs) {
+    setID(std::forward<S1>(rhs));
     isConstant_ = false;
     return *this;
   }
@@ -102,12 +99,13 @@ class AtomID {
 
   [[nodiscard]] inline const std::string& ID() const noexcept { return id_; }
 
-  inline void setID(const std::string& newID) {
-    if (validID(newID)) {
-      id_ = newID;
+  template<typename S1>
+  inline void setID(S1&& newID) {
+    if (validID(std::forward<S1>(newID))) {
+      id_ = std::forward<S1>(newID);
       position_.reset();
     } else {
-      throw cpet::value_error("Invalid AtomID " + newID);
+      throw cpet::value_error("Invalid AtomID " + std::string(newID));
     }
   }
 

--- a/include/Box.h
+++ b/include/Box.h
@@ -86,7 +86,7 @@ class Box : public Volume {
     return distribution(*util::randomNumberGenerator());
   }
 
-  [[nodiscard]] inline const std::string type() const noexcept override {
+  [[nodiscard]] inline std::string type() const noexcept override {
     return "box";
   }
 

--- a/include/Calculator.h
+++ b/include/Calculator.h
@@ -62,8 +62,7 @@ class Calculator {
       systems_.clear();
     }
 
-    const auto make_system =
-        [this](const Frame& frame) -> System {
+    const auto make_system = [this](const Frame& frame) -> System {
       return System{frame, this->option_};
     };
 

--- a/include/Calculator.h
+++ b/include/Calculator.h
@@ -79,9 +79,6 @@ class Calculator {
 
   void writeTopologyResults_(const std::vector<PathSample>& data,
                              const TopologyRegion& region, int i) const;
-
-  void writeEFieldResults_(
-      const std::vector<std::vector<Eigen::Vector3d>>& results) const;
 };
 }  // namespace cpet
 #endif  // CALCULATOR_H

--- a/include/Calculator.h
+++ b/include/Calculator.h
@@ -17,6 +17,8 @@
 #include "PointCharge.h"
 #include "System.h"
 #include "TopologyRegion.h"
+#include "Frame.h"
+
 namespace cpet {
 
 class Calculator {
@@ -41,7 +43,7 @@ class Calculator {
 
   int numberOfThreads_;
 
-  std::vector<std::vector<PointCharge>> pointChargeTrajectory_;
+  std::vector<Frame> frameTrajectory_;
 
   std::vector<System> systems_;
 
@@ -61,12 +63,12 @@ class Calculator {
     }
 
     const auto make_system =
-        [this](const std::vector<PointCharge>& trajectory) -> System {
-      return System{trajectory, this->option_};
+        [this](const Frame& frame) -> System {
+      return System{frame, this->option_};
     };
 
-    systems_.reserve(pointChargeTrajectory_.size());
-    std::transform(pointChargeTrajectory_.begin(), pointChargeTrajectory_.end(),
+    systems_.reserve(frameTrajectory_.size());
+    std::transform(frameTrajectory_.begin(), frameTrajectory_.end(),
                    std::back_inserter(systems_), make_system);
   }
 

--- a/include/EFieldVolume.h
+++ b/include/EFieldVolume.h
@@ -13,7 +13,7 @@
 #include <optional>
 #include <unordered_map>
 #include <numeric>
-#include <assert.h>
+#include <cassert>
 
 #include <Eigen/Dense>
 
@@ -87,9 +87,10 @@ class EFieldVolume {
     return output_;
   }
 
-  inline void output(const std::string& outputFile) {
+  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  inline void output(S1&& outputFile) {
     if (!outputFile.empty()) {
-      output_ = outputFile;
+      output_ = std::forward<S1>(outputFile);
     }
   }
 

--- a/include/EFieldVolume.h
+++ b/include/EFieldVolume.h
@@ -108,7 +108,6 @@ class EFieldVolume {
   void writeOutput_(
       const std::vector<System>& systems,
       const std::vector<std::vector<Eigen::Vector3d>>& results) const;
-
 };
 }  // namespace cpet
 #endif  // EFIELDVOLUME_H

--- a/include/EFieldVolume.h
+++ b/include/EFieldVolume.h
@@ -87,7 +87,8 @@ class EFieldVolume {
     return output_;
   }
 
-  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  template <typename S1, typename = typename std::enable_if<
+                             std::is_convertible_v<S1, std::string>>>
   inline void output(S1&& outputFile) {
     if (!outputFile.empty()) {
       output_ = std::forward<S1>(outputFile);

--- a/include/EFieldVolume.h
+++ b/include/EFieldVolume.h
@@ -60,12 +60,6 @@ class EFieldVolume {
             "; Volume: " + volume_->description());
   }
 
-  void plot(const std::vector<Eigen::Vector3d>& electricField) const;
-
-  void writeVolumeResults(
-      const std::vector<System>& systems,
-      const std::vector<std::vector<Eigen::Vector3d>>& results) const;
-
   [[nodiscard]] inline const Volume& volume() const noexcept {
     return *volume_;
   }
@@ -87,8 +81,7 @@ class EFieldVolume {
     return output_;
   }
 
-  template <typename S1, typename = typename std::enable_if<
-                             std::is_convertible_v<S1, std::string>>>
+  template <typename S1>
   inline void output(S1&& outputFile) {
     if (!outputFile.empty()) {
       output_ = std::forward<S1>(outputFile);
@@ -101,16 +94,21 @@ class EFieldVolume {
   [[nodiscard]] static EFieldVolume fromBlock(
       const std::vector<std::string>& options);
 
+  void computeVolumeWith(const std::vector<System>& systems) const;
+
  private:
   std::unique_ptr<Volume> volume_;
-
   std::array<int, 3> sampleDensity_;
-
   std::vector<Eigen::Vector3d> points_;
-
   bool showPlot_{false};
-
   std::optional<std::string> output_{std::nullopt};
+
+  void plot_(const std::vector<Eigen::Vector3d>& electricField) const;
+
+  void writeOutput_(
+      const std::vector<System>& systems,
+      const std::vector<std::vector<Eigen::Vector3d>>& results) const;
+
 };
 }  // namespace cpet
 #endif  // EFIELDVOLUME_H

--- a/include/Exceptions.h
+++ b/include/Exceptions.h
@@ -13,36 +13,42 @@ namespace cpet {
 
 class exception : public std::runtime_error {
  public:
-  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
-  explicit exception(S1&& what_arg) : std::runtime_error(std::forward<S1>(what_arg)){}
+  template <typename S1, typename = typename std::enable_if<
+                             std::is_convertible_v<S1, std::string>>>
+  explicit exception(S1&& what_arg)
+      : std::runtime_error(std::forward<S1>(what_arg)) {}
 };
 
 class value_error : public cpet::exception {
  public:
-  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  template <typename S1, typename = typename std::enable_if<
+                             std::is_convertible_v<S1, std::string>>>
   explicit value_error(S1&& what_arg)
       : cpet::exception(std::forward<S1>(what_arg)) {}
 };
 
 class value_not_found : public cpet::exception {
  public:
-  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  template <typename S1, typename = typename std::enable_if<
+                             std::is_convertible_v<S1, std::string>>>
   explicit value_not_found(S1&& what_arg)
-  : cpet::exception(std::forward<S1>(what_arg)) {}
+      : cpet::exception(std::forward<S1>(what_arg)) {}
 };
 
 class io_error : public cpet::exception {
  public:
-  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  template <typename S1, typename = typename std::enable_if<
+                             std::is_convertible_v<S1, std::string>>>
   explicit io_error(S1&& what_arg)
-  : cpet::exception(std::forward<S1>(what_arg)) {}
+      : cpet::exception(std::forward<S1>(what_arg)) {}
 };
 
 class invalid_option : public cpet::exception {
  public:
-  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  template <typename S1, typename = typename std::enable_if<
+                             std::is_convertible_v<S1, std::string>>>
   explicit invalid_option(S1&& what_arg)
-  : cpet::exception(std::forward<S1>(what_arg)) {}
+      : cpet::exception(std::forward<S1>(what_arg)) {}
 };
 }  // namespace cpet
 

--- a/include/Exceptions.h
+++ b/include/Exceptions.h
@@ -13,36 +13,36 @@ namespace cpet {
 
 class exception : public std::runtime_error {
  public:
-  explicit exception(const std::string& what_arg)
-      : std::runtime_error(what_arg) {}
-  explicit exception(const char* what_arg) : std::runtime_error(what_arg) {}
+  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  explicit exception(S1&& what_arg) : std::runtime_error(std::forward<S1>(what_arg)){}
 };
 
 class value_error : public cpet::exception {
  public:
-  explicit value_error(const std::string& what_arg)
-      : cpet::exception(what_arg) {}
-  explicit value_error(const char* what_arg) : cpet::exception(what_arg) {}
+  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  explicit value_error(S1&& what_arg)
+      : cpet::exception(std::forward<S1>(what_arg)) {}
 };
 
 class value_not_found : public cpet::exception {
  public:
-  explicit value_not_found(const std::string& what_arg)
-      : cpet::exception(what_arg) {}
-  explicit value_not_found(const char* what_arg) : cpet::exception(what_arg) {}
+  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  explicit value_not_found(S1&& what_arg)
+  : cpet::exception(std::forward<S1>(what_arg)) {}
 };
 
 class io_error : public cpet::exception {
  public:
-  explicit io_error(const std::string& what_arg) : cpet::exception(what_arg) {}
-  explicit io_error(const char* what_arg) : cpet::exception(what_arg) {}
+  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  explicit io_error(S1&& what_arg)
+  : cpet::exception(std::forward<S1>(what_arg)) {}
 };
 
 class invalid_option : public cpet::exception {
  public:
-  explicit invalid_option(const std::string& what_arg)
-      : cpet::exception(what_arg) {}
-  explicit invalid_option(const char* what_arg) : cpet::exception(what_arg) {}
+  template<typename S1, typename = typename std::enable_if<std::is_convertible_v<S1, std::string>>>
+  explicit invalid_option(S1&& what_arg)
+  : cpet::exception(std::forward<S1>(what_arg)) {}
 };
 }  // namespace cpet
 

--- a/include/FieldLocations.h
+++ b/include/FieldLocations.h
@@ -70,9 +70,10 @@ class FieldLocations {
     return output_;
   }
 
-  void output(std::string output_name) {
+  template<typename S1>
+  void output(S1&& output_name) {
     if (!output_name.empty()) {
-      output_ = std::move(output_name);
+      output_ = std::forward<S1>(output_name);
     }
   }
 
@@ -131,7 +132,6 @@ class FieldLocations {
 
   void plot_(const std::vector<std::vector<Eigen::Vector3d>>& results) const;
 };
-
 }  // namespace cpet
 
 #endif  // FIELDLOCATIONS_H

--- a/include/FieldLocations.h
+++ b/include/FieldLocations.h
@@ -129,8 +129,7 @@ class FieldLocations {
   void writeOutput_(
       const std::vector<std::vector<Eigen::Vector3d>>& results) const;
 
-  void plot_(
-      const std::vector<std::vector<Eigen::Vector3d>>& results) const;
+  void plot_(const std::vector<std::vector<Eigen::Vector3d>>& results) const;
 };
 
 }  // namespace cpet

--- a/include/FieldLocations.h
+++ b/include/FieldLocations.h
@@ -17,7 +17,11 @@
 #include "PointCharge.h"
 
 namespace cpet {
+
+/* Prevents circular inclusion */
 class System;
+
+/* We use bitmap to determine what to plot */
 enum class PlotStyles : uint32_t {
   x = 1 << 0,
   y = 1 << 1,
@@ -122,6 +126,9 @@ class FieldLocations {
   }
 
   void writeOutput_(
+      const std::vector<std::vector<Eigen::Vector3d>>& results) const;
+
+  void plot_(
       const std::vector<std::vector<Eigen::Vector3d>>& results) const;
 };
 

--- a/include/FieldLocations.h
+++ b/include/FieldLocations.h
@@ -1,0 +1,130 @@
+// Copyright(c) 2020-Present, Matthew R. Hennefarth
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#ifndef FIELDLOCATIONS_H
+#define FIELDLOCATIONS_H
+
+/* C++ STL HEADER FILES */
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include <optional>
+
+/* CPET HEADER FILES */
+#include "AtomID.h"
+#include "Exceptions.h"
+#include "Utilities.h"
+#include "PointCharge.h"
+
+namespace cpet {
+class System;
+enum class PlotStyles : uint32_t {
+  x = 1 << 0,
+  y = 1 << 1,
+  z = 1 << 2,
+  m = 1 << 3
+};
+
+constexpr PlotStyles operator|(const PlotStyles lhs, const PlotStyles rhs) {
+  return static_cast<PlotStyles>(
+      static_cast<std::underlying_type<PlotStyles>::type>(lhs) |
+      static_cast<std::underlying_type<PlotStyles>::type>(rhs));
+}
+constexpr PlotStyles operator&(const PlotStyles lhs, const PlotStyles rhs) {
+  return static_cast<PlotStyles>(
+      static_cast<std::underlying_type<PlotStyles>::type>(lhs) &
+      static_cast<std::underlying_type<PlotStyles>::type>(rhs));
+}
+
+constexpr PlotStyles& operator|=(PlotStyles& lhs, const PlotStyles rhs) {
+  lhs = static_cast<PlotStyles>(
+      static_cast<std::underlying_type<PlotStyles>::type>(lhs) |
+      static_cast<std::underlying_type<PlotStyles>::type>(rhs));
+  return lhs;
+}
+
+class FieldLocations {
+ public:
+  void computeEFieldsWith(
+      const std::vector<System>& systems,
+      const std::vector<std::vector<PointCharge>>& pointChargeTrajectory) const;
+
+  [[nodiscard]] constexpr const std::vector<AtomID>& locations()
+      const noexcept {
+    return locations_;
+  }
+
+  [[nodiscard]] inline const PlotStyles& plotStyle() const noexcept {
+    return plotStyle_;
+  }
+  void plotStyle(const std::vector<std::string>& tokens) {
+    plotStyle_ = decodePlotStyle_(tokens);
+  }
+
+  [[nodiscard]] constexpr const std::optional<std::string>& output()
+      const noexcept {
+    return output_;
+  }
+
+  void output(std::string output_name) {
+    if (!output_name.empty()) {
+      output_ = std::move(output_name);
+    }
+  }
+
+  [[nodiscard]] bool showPlots() const noexcept {
+    // Check if user specified any plots
+    return util::countSetBits(static_cast<unsigned int>(plotStyle_)) != 0;
+  }
+
+  [[nodiscard]] static FieldLocations fromSimple(
+      const std::vector<std::string>& options);
+
+  [[nodiscard]] static FieldLocations fromBlock(
+      const std::vector<std::string>& options);
+
+ private:
+  std::vector<AtomID> locations_;
+  PlotStyles plotStyle_;
+  std::optional<std::string> output_{std::nullopt};
+
+  [[nodiscard]] inline static PlotStyles decodePlotStyle_(
+      const std::vector<std::string>& tokens) {
+    const static std::unordered_map<std::string, PlotStyles> plotHash = {
+        {"x", PlotStyles::x},
+        {"y", PlotStyles::y},
+        {"z", PlotStyles::z},
+        {"m", PlotStyles::m}};
+    PlotStyles plotstyle{0};
+    for (const auto& token : tokens) {
+      const auto iter = plotHash.find(token);
+      if (iter == plotHash.end()) {
+        // Unknown token passed
+        throw cpet::invalid_option(
+            "Invalid Option: Unknown plot token specified: " + token);
+      }
+      plotstyle |= iter->second;
+    }
+    return plotstyle;
+  }
+
+  [[nodiscard]] constexpr bool plotX_() const noexcept {
+    return ((plotStyle_ & PlotStyles::x) == PlotStyles::x);
+  }
+  [[nodiscard]] constexpr bool plotY_() const noexcept {
+    return ((plotStyle_ & PlotStyles::y) == PlotStyles::y);
+  }
+  [[nodiscard]] constexpr bool plotZ_() const noexcept {
+    return ((plotStyle_ & PlotStyles::z) == PlotStyles::z);
+  }
+  [[nodiscard]] constexpr bool plotM_() const noexcept {
+    return ((plotStyle_ & PlotStyles::m) == PlotStyles::m);
+  }
+
+  void writeOutput_(
+      const std::vector<std::vector<Eigen::Vector3d>>& results) const;
+};
+
+}  // namespace cpet
+
+#endif  // FIELDLOCATIONS_H

--- a/include/FieldLocations.h
+++ b/include/FieldLocations.h
@@ -98,10 +98,11 @@ class FieldLocations {
         {"x", PlotStyles::x},
         {"y", PlotStyles::y},
         {"z", PlotStyles::z},
-        {"m", PlotStyles::m}};
+        {"m", PlotStyles::m},
+        {"all", PlotStyles::x | PlotStyles::y | PlotStyles::z | PlotStyles::m}};
     PlotStyles plotstyle{0};
     for (const auto& token : tokens) {
-      const auto iter = plotHash.find(token);
+      const auto iter = plotHash.find(util::tolower(token));
       if (iter == plotHash.end()) {
         // Unknown token passed
         throw cpet::invalid_option(

--- a/include/FieldLocations.h
+++ b/include/FieldLocations.h
@@ -50,8 +50,7 @@ constexpr PlotStyles& operator|=(PlotStyles& lhs, const PlotStyles rhs) {
 class FieldLocations {
  public:
   void computeEFieldsWith(
-      const std::vector<System>& systems,
-      const std::vector<std::vector<PointCharge>>& pointChargeTrajectory) const;
+      const std::vector<System>& systems) const;
 
   [[nodiscard]] constexpr const std::vector<AtomID>& locations()
       const noexcept {

--- a/include/FieldLocations.h
+++ b/include/FieldLocations.h
@@ -85,7 +85,7 @@ class FieldLocations {
 
  private:
   std::vector<AtomID> locations_;
-  PlotStyles plotStyle_;
+  PlotStyles plotStyle_{0};
   std::optional<std::string> output_{std::nullopt};
 
   [[nodiscard]] inline static PlotStyles decodePlotStyle_(

--- a/include/FieldLocations.h
+++ b/include/FieldLocations.h
@@ -49,8 +49,7 @@ constexpr PlotStyles& operator|=(PlotStyles& lhs, const PlotStyles rhs) {
 
 class FieldLocations {
  public:
-  void computeEFieldsWith(
-      const std::vector<System>& systems) const;
+  void computeEFieldsWith(const std::vector<System>& systems) const;
 
   [[nodiscard]] constexpr const std::vector<AtomID>& locations()
       const noexcept {
@@ -69,7 +68,7 @@ class FieldLocations {
     return output_;
   }
 
-  template<typename S1>
+  template <typename S1>
   void output(S1&& output_name) {
     if (!output_name.empty()) {
       output_ = std::forward<S1>(output_name);

--- a/include/Frame.h
+++ b/include/Frame.h
@@ -15,22 +15,25 @@
 #include "PointCharge.h"
 #include "Utilities.h"
 
-namespace cpet{
+namespace cpet {
 
 class Frame {
  public:
   Frame(const std::vector<PointCharge>& pcs) : pointCharges_(pcs) {}
 
-  [[nodiscard]] inline std::vector<PointCharge>::const_iterator find(const AtomID& id) const {
+  [[nodiscard]] inline std::vector<PointCharge>::const_iterator find(
+      const AtomID& id) const {
     return util::find_if_ex(pointCharges_.begin(), pointCharges_.end(),
                             [&id](const auto& pc) { return pc.id == id; });
   }
 
-  [[nodiscard]] inline std::vector<PointCharge>::const_iterator begin() const noexcept {
+  [[nodiscard]] inline std::vector<PointCharge>::const_iterator begin()
+      const noexcept {
     return pointCharges_.begin();
   }
 
-  [[nodiscard]] inline std::vector<PointCharge>::const_iterator end() const noexcept {
+  [[nodiscard]] inline std::vector<PointCharge>::const_iterator end()
+      const noexcept {
     return pointCharges_.end();
   }
 
@@ -42,19 +45,23 @@ class Frame {
     return pointCharges_.end();
   }
 
-  [[nodiscard]] inline std::vector<PointCharge>::const_reverse_iterator rbegin() const noexcept {
+  [[nodiscard]] inline std::vector<PointCharge>::const_reverse_iterator rbegin()
+      const noexcept {
     return pointCharges_.rbegin();
   }
 
-  [[nodiscard]] inline std::vector<PointCharge>::const_reverse_iterator rend() const noexcept {
+  [[nodiscard]] inline std::vector<PointCharge>::const_reverse_iterator rend()
+      const noexcept {
     return pointCharges_.rend();
   }
 
-  [[nodiscard]] inline std::vector<PointCharge>::reverse_iterator rbegin() noexcept {
+  [[nodiscard]] inline std::vector<PointCharge>::reverse_iterator
+  rbegin() noexcept {
     return pointCharges_.rbegin();
   }
 
-  [[nodiscard]] inline std::vector<PointCharge>::reverse_iterator rend() noexcept {
+  [[nodiscard]] inline std::vector<PointCharge>::reverse_iterator
+  rend() noexcept {
     return pointCharges_.rend();
   }
 
@@ -65,7 +72,7 @@ class Frame {
       throw cpet::value_error(
           "Inconsistent number of point charges in trajectory and in charge "
           "file");
-      }
+    }
     for (size_t i = 0; i < pointCharges_.size(); i++) {
       pointCharges_[i].charge = charges[i];
     }
@@ -75,5 +82,5 @@ class Frame {
   std::vector<PointCharge> pointCharges_;
 };
 
-}
+}  // namespace cpet
 #endif  // FRAME_H

--- a/include/Frame.h
+++ b/include/Frame.h
@@ -1,0 +1,79 @@
+// Copyright(c) 2020-Present, Matthew R. Hennefarth
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#ifndef FRAME_H
+#define FRAME_H
+
+/* C++ STL HEADER FILES */
+#include <vector>
+#include <algorithm>
+
+/* EXTERNAL LIBRARY HEADER FILES */
+#include <spdlog/spdlog.h>
+
+/* CPET HEADER FILES */
+#include "PointCharge.h"
+#include "Utilities.h"
+
+namespace cpet{
+
+class Frame {
+ public:
+  Frame(const std::vector<PointCharge>& pcs) : pointCharges_(pcs) {}
+
+  [[nodiscard]] inline std::vector<PointCharge>::const_iterator find(const AtomID& id) const {
+    return util::find_if_ex(pointCharges_.begin(), pointCharges_.end(),
+                            [&id](const auto& pc) { return pc.id == id; });
+  }
+
+  [[nodiscard]] inline std::vector<PointCharge>::const_iterator begin() const noexcept {
+    return pointCharges_.begin();
+  }
+
+  [[nodiscard]] inline std::vector<PointCharge>::const_iterator end() const noexcept {
+    return pointCharges_.end();
+  }
+
+  [[nodiscard]] inline std::vector<PointCharge>::iterator begin() noexcept {
+    return pointCharges_.begin();
+  }
+
+  [[nodiscard]] inline std::vector<PointCharge>::iterator end() noexcept {
+    return pointCharges_.end();
+  }
+
+  [[nodiscard]] inline std::vector<PointCharge>::const_reverse_iterator rbegin() const noexcept {
+    return pointCharges_.rbegin();
+  }
+
+  [[nodiscard]] inline std::vector<PointCharge>::const_reverse_iterator rend() const noexcept {
+    return pointCharges_.rend();
+  }
+
+  [[nodiscard]] inline std::vector<PointCharge>::reverse_iterator rbegin() noexcept {
+    return pointCharges_.rbegin();
+  }
+
+  [[nodiscard]] inline std::vector<PointCharge>::reverse_iterator rend() noexcept {
+    return pointCharges_.rend();
+  }
+
+  inline void updateCharges(const std::vector<double>& charges) {
+    if (pointCharges_.size() != charges.size()) {
+      SPDLOG_ERROR("Structure size: {}, number of charges: {}",
+                   pointCharges_.size(), charges.size());
+      throw cpet::value_error(
+          "Inconsistent number of point charges in trajectory and in charge "
+          "file");
+      }
+    for (size_t i = 0; i < pointCharges_.size(); i++) {
+      pointCharges_[i].charge = charges[i];
+    }
+  }
+
+ private:
+  std::vector<PointCharge> pointCharges_;
+};
+
+}
+#endif  // FRAME_H

--- a/include/Option.h
+++ b/include/Option.h
@@ -56,7 +56,7 @@ class Option {
     return centerID_;
   }
 
-  template<typename S1>
+  template <typename S1>
   constexpr void centerID(S1&& atomid) {
     centerID_ = std::forward<S1>(atomid);
   }

--- a/include/Option.h
+++ b/include/Option.h
@@ -40,13 +40,19 @@ class Option {
 
   AtomID direction2ID{AtomID::Constants::e2};
 
-  std::vector<TopologyRegion> calculateEFieldTopology;
-
-  std::vector<EFieldVolume> calculateEFieldVolumes;
-
   [[nodiscard]] constexpr const std::vector<FieldLocations>&
   calculateFieldLocations() const noexcept {
     return calculateFieldLocations_;
+  }
+
+  [[nodiscard]] constexpr const std::vector<EFieldVolume>&
+  calculateEFieldVolumes() const noexcept {
+    return calculateEFieldVolumes_;
+  }
+
+  [[nodiscard]] constexpr const std::vector<TopologyRegion>&
+  calculateEFieldTopology() const noexcept {
+    return calculateEFieldTopology_;
   }
 
   inline void addFieldLocations(const FieldLocations& fl) {
@@ -55,6 +61,8 @@ class Option {
 
  private:
   std::vector<FieldLocations> calculateFieldLocations_;
+  std::vector<EFieldVolume> calculateEFieldVolumes_;
+  std::vector<TopologyRegion> calculateEFieldTopology_;
 
   std::vector<std::string> simpleOptions_;
   std::vector<std::pair<std::string, std::vector<std::string>>> blockOptions_;
@@ -92,7 +100,7 @@ class Option {
     }
     std::unique_ptr<Volume> vol = Volume::generateVolume(
         std::vector<std::string>{options.begin() + 1, options.end()});
-    calculateEFieldTopology.emplace_back(std::move(vol), samples);
+    calculateEFieldTopology_.emplace_back(std::move(vol), samples);
   }
 
   inline void parseFieldSimple_(const std::vector<std::string>& options) {
@@ -104,11 +112,11 @@ class Option {
   }
 
   inline void parsePlot3dSimple_(const std::vector<std::string>& options) {
-    calculateEFieldVolumes.emplace_back(EFieldVolume::fromSimple(options));
+    calculateEFieldVolumes_.emplace_back(EFieldVolume::fromSimple(options));
   }
 
   inline void parsePlot3dBlock_(const std::vector<std::string>& blockOptions) {
-    calculateEFieldVolumes.emplace_back(EFieldVolume::fromBlock(blockOptions));
+    calculateEFieldVolumes_.emplace_back(EFieldVolume::fromBlock(blockOptions));
   }
 };
 }  // namespace cpet

--- a/include/Option.h
+++ b/include/Option.h
@@ -31,18 +31,15 @@ constexpr const char* PLOT_3D_KEY = "plot3d";
 class Option {
  public:
   Option() = default;
-
   explicit Option(const std::string& optionFile);
-
-  AtomID centerID{AtomID::Constants::origin};
-
-  AtomID direction1ID{AtomID::Constants::e1};
-
-  AtomID direction2ID{AtomID::Constants::e2};
 
   [[nodiscard]] constexpr const std::vector<FieldLocations>&
   calculateFieldLocations() const noexcept {
     return calculateFieldLocations_;
+  }
+
+  inline void addFieldLocations(const FieldLocations& fl) {
+    calculateFieldLocations_.emplace_back(fl);
   }
 
   [[nodiscard]] constexpr const std::vector<EFieldVolume>&
@@ -55,20 +52,37 @@ class Option {
     return calculateEFieldTopology_;
   }
 
-  inline void addFieldLocations(const FieldLocations& fl) {
-    calculateFieldLocations_.emplace_back(fl);
+  [[nodiscard]] constexpr const AtomID& centerID() const noexcept {
+    return centerID_;
+  }
+
+  template<typename S1>
+  constexpr void centerID(S1&& atomid) {
+    centerID_ = std::forward<S1>(atomid);
+  }
+
+  [[nodiscard]] constexpr const AtomID& direction1ID() const noexcept {
+    return direction1ID_;
+  }
+
+  [[nodiscard]] constexpr const AtomID& direction2ID() const noexcept {
+    return direction2ID_;
   }
 
  private:
   std::vector<FieldLocations> calculateFieldLocations_;
   std::vector<EFieldVolume> calculateEFieldVolumes_;
   std::vector<TopologyRegion> calculateEFieldTopology_;
-
+  AtomID centerID_{AtomID::Constants::origin};
+  AtomID direction1ID_{AtomID::Constants::e1};
+  AtomID direction2ID_{AtomID::Constants::e2};
   std::vector<std::string> simpleOptions_;
   std::vector<std::pair<std::string, std::vector<std::string>>> blockOptions_;
 
   void loadOptionsDataFromFile_(const std::string& optionFile);
+
   void parseSimpleOptions_();
+
   void parseBlockOptions_();
 
   inline void parseAlignSimple_(const std::vector<std::string>& options) {
@@ -76,10 +90,10 @@ class Option {
       throw cpet::invalid_option(
           "Invalid Option: align expects 1 or 3 identifiers");
     }
-    centerID = options.at(0);
+    centerID_ = options.at(0);
     if (options.size() > 1) {
-      direction1ID = options.at(1);
-      direction2ID = options.at(2);
+      direction1ID_ = options.at(1);
+      direction2ID_ = options.at(2);
     }
   }
 

--- a/include/Option.h
+++ b/include/Option.h
@@ -110,18 +110,6 @@ class Option {
   inline void parsePlot3dBlock_(const std::vector<std::string>& blockOptions) {
     calculateEFieldVolumes.emplace_back(EFieldVolume::fromBlock(blockOptions));
   }
-
-  inline static const std::unordered_map<
-      std::string, void (Option::*)(const std::vector<std::string>&)>
-      parseSimpleOptionsMap_ = {{ALIGN_KEY, &Option::parseAlignSimple_},
-                                {TOPOLOGY_KEY, &Option::parseTopologySimple_},
-                                {FIELD_KEY, &Option::parseFieldSimple_},
-                                {PLOT_3D_KEY, &Option::parsePlot3dSimple_}};
-
-  inline static const std::unordered_map<
-      std::string, void (Option::*)(const std::vector<std::string>&)>
-      parseBlockOptionsMap_ = {{PLOT_3D_KEY, &Option::parsePlot3dBlock_},
-                               {FIELD_KEY, &Option::parseFieldBlock_}};
 };
 }  // namespace cpet
 #endif  // OPTION_H

--- a/include/PointCharge.h
+++ b/include/PointCharge.h
@@ -29,7 +29,6 @@ struct PointCharge {
     return (coordinate == pc.coordinate) && (charge == pc.charge) &&
            (id == pc.id);
   }
-
 };
 }  // namespace cpet
 #endif  // POINTCHARGE_H

--- a/include/PointCharge.h
+++ b/include/PointCharge.h
@@ -25,27 +25,11 @@ struct PointCharge {
   inline PointCharge(Eigen::Vector3d coord, double q, AtomID aid) noexcept
       : coordinate(std::move(coord)), charge(q), id(std::move(aid)) {}
 
-  PointCharge(PointCharge&&) = default;
-
-  PointCharge(const PointCharge&) = default;
-
-  inline PointCharge& operator=(const PointCharge&) noexcept = default;
-
-  inline PointCharge& operator=(PointCharge&&) noexcept = default;
-
   [[nodiscard]] inline bool operator==(const PointCharge& pc) const {
     return (coordinate == pc.coordinate) && (charge == pc.charge) &&
            (id == pc.id);
   }
 
-  ~PointCharge() = default;
-
-  [[nodiscard]] static inline auto find(
-      const std::vector<PointCharge>& pointCharges, const AtomID& id)
-      -> decltype(pointCharges.begin()) {
-    return util::find_if_ex(begin(pointCharges), end(pointCharges),
-                            [&id](const auto& pc) { return pc.id == id; });
-  }
-} __attribute__((aligned(128)));
+};
 }  // namespace cpet
 #endif  // POINTCHARGE_H

--- a/include/System.h
+++ b/include/System.h
@@ -74,6 +74,11 @@ class System {
   [[nodiscard]] std::vector<Eigen::Vector3d> computeElectricFieldIn(
       const EFieldVolume& volume) const noexcept;
 
+  [[nodiscard]] constexpr const std::vector<PointCharge>& pointCharges()
+      const noexcept {
+    return pointCharges_;
+  }
+
  private:
   static inline void constructOrthonormalBasis_(
       std::array<Eigen::Vector3d, 3>& basis) noexcept {

--- a/include/System.h
+++ b/include/System.h
@@ -75,10 +75,7 @@ class System {
   [[nodiscard]] std::vector<Eigen::Vector3d> computeElectricFieldIn(
       const EFieldVolume& volume) const noexcept;
 
-  [[nodiscard]] constexpr const Frame& frame()
-      const noexcept {
-    return frame_;
-  }
+  [[nodiscard]] constexpr const Frame& frame() const noexcept { return frame_; }
 
  private:
   static inline void constructOrthonormalBasis_(

--- a/include/System.h
+++ b/include/System.h
@@ -36,7 +36,7 @@ struct PathSample {
     os << ps.distance << ',' << ps.curvature;
     return os;
   }
-} __attribute__((aligned(16)));
+};
 
 class System {
  public:

--- a/include/System.h
+++ b/include/System.h
@@ -22,6 +22,7 @@
 #include "TopologyRegion.h"
 #include "Utilities.h"
 #include "Volume.h"
+#include "Frame.h"
 
 // TODO maybe make this an option?
 #define STEP_SIZE 0.001
@@ -40,7 +41,7 @@ struct PathSample {
 
 class System {
  public:
-  System(std::vector<PointCharge> pc, const Option& options);
+  System(const Frame& frame, const Option& options);
 
   [[nodiscard]] Eigen::Vector3d electricFieldAt(
       const Eigen::Vector3d& position) const;
@@ -74,9 +75,9 @@ class System {
   [[nodiscard]] std::vector<Eigen::Vector3d> computeElectricFieldIn(
       const EFieldVolume& volume) const noexcept;
 
-  [[nodiscard]] constexpr const std::vector<PointCharge>& pointCharges()
+  [[nodiscard]] constexpr const Frame& frame()
       const noexcept {
-    return pointCharges_;
+    return frame_;
   }
 
  private:
@@ -98,7 +99,8 @@ class System {
 
   inline void forEachPointCharge_(
       const std::function<void(PointCharge&)>& func) {
-    std::for_each(begin(pointCharges_), end(pointCharges_), func);
+    std::for_each(pointCharges_.begin(), pointCharges_.end(), func);
+    std::for_each(frame_.begin(), frame_.end(), func);
   }
 
   inline void translateSystemTo_(const Eigen::Vector3d& position) {
@@ -142,6 +144,7 @@ class System {
     return (pos + STEP_SIZE * f);
   }
 
+  Frame frame_;
   std::vector<PointCharge> pointCharges_;
   Eigen::Vector3d center_;
   Eigen::Matrix3d basisMatrix_;

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -29,8 +29,8 @@ randomNumberGenerator() noexcept {
   return generator;
 }
 
-[[nodiscard]] inline std::string lstrip(std::string_view str,
-                                        std::string_view escape = " \t") {
+[[nodiscard]] inline std::string lstrip(const std::string_view str,
+                                        const std::string_view escape = " \t") {
   auto strBegin = str.find_first_not_of(escape);
   if (strBegin > str.size()) {
     return std::string{};
@@ -38,8 +38,8 @@ randomNumberGenerator() noexcept {
   return str.substr(strBegin).data();
 }
 
-[[nodiscard]] inline std::string rstrip(std::string_view str,
-                                        std::string_view escape = " \t") {
+[[nodiscard]] inline std::string rstrip(const std::string_view str,
+                                        const std::string_view escape = " \t") {
   auto strEnd = str.find_last_not_of(escape);
   if (strEnd == std::string::npos) {
     return str.data();
@@ -47,8 +47,8 @@ randomNumberGenerator() noexcept {
   return {str.data(), strEnd + 1};
 }
 
-[[nodiscard]] inline std::string removeAfter(std::string_view str,
-                                             std::string_view escape = " \t") {
+[[nodiscard]] inline std::string removeAfter(const std::string_view str,
+                                             const std::string_view escape = " \t") {
   auto strEnd = str.find_first_of(escape);
   if (strEnd == std::string::npos) {
     return str.data();
@@ -64,12 +64,12 @@ randomNumberGenerator() noexcept {
 void forEachLineIn(const std::string& file,
                    const std::function<void(const std::string&)>& func);
 
-std::vector<std::string> split(std::string_view str, char delim);
+std::vector<std::string> split(const std::string_view str, char delim);
 
 [[nodiscard]] bool isDouble(std::string str) noexcept;
 
 template <class InputIt, class UnaryPredicate>
-InputIt find_if_ex(InputIt first, InputIt last, UnaryPredicate p) {
+InputIt find_if_ex(const InputIt first, const InputIt last, const UnaryPredicate p) {
   if (auto loc = std::find_if(first, last, p); loc != last) {
     return loc;
   }
@@ -85,7 +85,7 @@ constexpr unsigned int countSetBits(unsigned int n) {
   return count;
 }
 
-inline std::string tolower(const std::string& str) {
+inline std::string tolower(const std::string_view str) {
   std::string result;
   std::transform(str.begin(), str.end(), std::back_inserter(result),
                  [](const char& c) { return std::tolower(c); });

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -87,9 +87,8 @@ constexpr unsigned int countSetBits(unsigned int n) {
 
 inline std::string tolower(const std::string& str) {
   std::string result;
-  std::transform(str.begin(), str.end(), std::back_inserter(result), [](const char & c){
-    return std::tolower(c);
-  });
+  std::transform(str.begin(), str.end(), std::back_inserter(result),
+                 [](const char& c) { return std::tolower(c); });
   return result;
 }
 }  // namespace util

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -84,6 +84,14 @@ constexpr unsigned int countSetBits(unsigned int n) {
   }
   return count;
 }
+
+inline std::string tolower(const std::string& str) {
+  std::string result;
+  std::transform(str.begin(), str.end(), std::back_inserter(result), [](const char & c){
+    return std::tolower(c);
+  });
+  return result;
+}
 }  // namespace util
 }  // namespace cpet
 #endif  // UTILITIES_H

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -13,8 +13,6 @@
 #include <vector>
 #include <memory>
 
-#include <iostream>
-
 /* CPET HEADER FILES */
 #include "Exceptions.h"
 namespace cpet {
@@ -87,6 +85,7 @@ constexpr unsigned int countSetBits(unsigned int n) {
 
 inline std::string tolower(const std::string_view str) {
   std::string result;
+  result.reserve(str.size());
   std::transform(str.begin(), str.end(), std::back_inserter(result),
                  [](const char& c) { return std::tolower(c); });
   return result;

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -75,6 +75,15 @@ InputIt find_if_ex(InputIt first, InputIt last, UnaryPredicate p) {
   }
   throw cpet::value_not_found("Could not find element in container");
 }
+
+constexpr unsigned int countSetBits(unsigned int n) {
+  unsigned int count = 0;
+  while (n != 0) {
+    count += n & 1;
+    n >>= 1;
+  }
+  return count;
+}
 }  // namespace util
 }  // namespace cpet
 #endif  // UTILITIES_H

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -45,8 +45,8 @@ randomNumberGenerator() noexcept {
   return {str.data(), strEnd + 1};
 }
 
-[[nodiscard]] inline std::string removeAfter(const std::string_view str,
-                                             const std::string_view escape = " \t") {
+[[nodiscard]] inline std::string removeAfter(
+    const std::string_view str, const std::string_view escape = " \t") {
   auto strEnd = str.find_first_of(escape);
   if (strEnd == std::string::npos) {
     return str.data();
@@ -67,7 +67,8 @@ std::vector<std::string> split(const std::string_view str, char delim);
 [[nodiscard]] bool isDouble(std::string str) noexcept;
 
 template <class InputIt, class UnaryPredicate>
-InputIt find_if_ex(const InputIt first, const InputIt last, const UnaryPredicate p) {
+InputIt find_if_ex(const InputIt first, const InputIt last,
+                   const UnaryPredicate p) {
   if (auto loc = std::find_if(first, last, p); loc != last) {
     return loc;
   }

--- a/include/Volume.h
+++ b/include/Volume.h
@@ -37,14 +37,14 @@ class Volume {
 
   [[nodiscard]] virtual int randomDistance(double stepSize) const noexcept = 0;
 
-  [[nodiscard]] virtual const std::string type() const noexcept = 0;
+  [[nodiscard]] virtual std::string type() const noexcept = 0;
 
   [[nodiscard]] virtual std::vector<Eigen::Vector3d> partition(
       const std::array<int, 3> &density) const noexcept = 0;
 
  public:
   static std::unique_ptr<Volume> generateVolume(
-      std::vector<std::string> options);
+      const std::vector<std::string>& options);
 };
 }  // namespace cpet
 #endif  // VOLUME_H

--- a/include/Volume.h
+++ b/include/Volume.h
@@ -44,7 +44,7 @@ class Volume {
 
  public:
   static std::unique_ptr<Volume> generateVolume(
-      const std::vector<std::string>& options);
+      const std::vector<std::string> &options);
 };
 }  // namespace cpet
 #endif  // VOLUME_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-set( SOURCE_FILES main.cpp Utilities.cpp System.cpp Option.cpp Calculator.cpp EFieldVolume.cpp Volume.cpp)
+set( SOURCE_FILES main.cpp Utilities.cpp System.cpp Option.cpp Calculator.cpp EFieldVolume.cpp Volume.cpp FieldLocations.cpp)
 include_directories( ${PROJECT_SOURCE_DIR}/include )
 
 #---------------------------------------------------[Main Executable]---------------------------------------------------

--- a/src/Calculator.cpp
+++ b/src/Calculator.cpp
@@ -155,9 +155,9 @@ std::vector<double> Calculator::loadChargesFile_() const {
 void Calculator::fixCharges_() {
   SPDLOG_DEBUG("Fixing charges in structure file with real charges...");
   auto realCharges = loadChargesFile_();
-  std::for_each(frameTrajectory_.begin(), frameTrajectory_.end(), [&realCharges](auto& frame){
-    frame.updateCharges(realCharges);
-  });
+  std::for_each(
+      frameTrajectory_.begin(), frameTrajectory_.end(),
+      [&realCharges](auto& frame) { frame.updateCharges(realCharges); });
 }
 
 void Calculator::writeTopologyResults_(const std::vector<PathSample>& data,

--- a/src/Calculator.cpp
+++ b/src/Calculator.cpp
@@ -98,21 +98,7 @@ void Calculator::computeVolume_() const {
   std::for_each(
       option_.calculateEFieldVolumes().begin(),
       option_.calculateEFieldVolumes().end(), [this](const auto& volume) {
-        std::vector<std::vector<Eigen::Vector3d>> volumeResults;
-        volumeResults.reserve(systems_.size());
-        const auto compute_volume_data = [&volume](const System& system) {
-          system.printCenterAndBasis();
-          auto tmpSystemResults = system.computeElectricFieldIn(volume);
-          if (volume.showPlot()) {
-            volume.plot(tmpSystemResults);
-          }
-          return tmpSystemResults;
-        };
-        std::transform(systems_.begin(), systems_.end(),
-                       std::back_inserter(volumeResults), compute_volume_data);
-        if (volume.output()) {
-          volume.writeVolumeResults(systems_, volumeResults);
-        }
+        volume.computeVolumeWith(systems_);
       });
 }
 

--- a/src/Calculator.cpp
+++ b/src/Calculator.cpp
@@ -97,9 +97,8 @@ void Calculator::computeEField_() const {
 void Calculator::computeVolume_() const {
   std::for_each(
       option_.calculateEFieldVolumes().begin(),
-      option_.calculateEFieldVolumes().end(), [this](const auto& volume) {
-        volume.computeVolumeWith(systems_);
-      });
+      option_.calculateEFieldVolumes().end(),
+      [this](const auto& volume) { volume.computeVolumeWith(systems_); });
 }
 
 void Calculator::loadPointChargeTrajectory_() {

--- a/src/Calculator.cpp
+++ b/src/Calculator.cpp
@@ -43,13 +43,13 @@ void Calculator::compute() {
   createSystems_();
   transformSystems_();
 
-  if (!option_.calculateEFieldTopology.empty()) {
+  if (!option_.calculateEFieldTopology().empty()) {
     computeTopology_();
   }
   if (!option_.calculateFieldLocations().empty()) {
     computeEField_();
   }
-  if (!option_.calculateEFieldVolumes.empty()) {
+  if (!option_.calculateEFieldVolumes().empty()) {
     computeVolume_();
   }
 }
@@ -78,8 +78,8 @@ void Calculator::computeTopology_() const {
                 [&, index = 0](const auto& system) mutable {
                   SPDLOG_INFO("=~=~=~=~[Trajectory {}]=~=~=~=~", index);
                   system.printCenterAndBasis();
-                  std::for_each(option_.calculateEFieldTopology.begin(),
-                                option_.calculateEFieldTopology.end(),
+                  std::for_each(option_.calculateEFieldTopology().begin(),
+                                option_.calculateEFieldTopology().end(),
                                 [&](const auto& region) {
                                   print_header(region);
                                   compute_topology(system, region, index);
@@ -96,8 +96,8 @@ void Calculator::computeEField_() const {
 
 void Calculator::computeVolume_() const {
   std::for_each(
-      option_.calculateEFieldVolumes.begin(),
-      option_.calculateEFieldVolumes.end(), [this](const auto& volume) {
+      option_.calculateEFieldVolumes().begin(),
+      option_.calculateEFieldVolumes().end(), [this](const auto& volume) {
         std::vector<std::vector<Eigen::Vector3d>> volumeResults;
         volumeResults.reserve(systems_.size());
         const auto compute_volume_data = [&volume](const System& system) {

--- a/src/EFieldVolume.cpp
+++ b/src/EFieldVolume.cpp
@@ -138,7 +138,7 @@ EFieldVolume EFieldVolume::fromBlock(const std::vector<std::string>& options) {
   constexpr const char* OUTPUT_KEY = "output";
 
   for (const auto& line : options) {
-    auto tokens = util::split(line, ' ');
+    const auto tokens = util::split(line, ' ');
     if (tokens.size() < 2) {
       continue;
     }

--- a/src/EFieldVolume.cpp
+++ b/src/EFieldVolume.cpp
@@ -17,8 +17,6 @@ namespace cpet {
 
 constexpr int DENSITY_PARAMETERS = 3;
 
-
-
 EFieldVolume EFieldVolume::fromSimple(const std::vector<std::string>& options) {
   constexpr bool plot = true;
   constexpr size_t MIN_EFIELDVOLUME_OPTIONS = 5;
@@ -129,7 +127,6 @@ void EFieldVolume::computeVolumeWith(const std::vector<System>& systems) const {
   if (output_) {
     writeOutput_(systems, volumeResults);
   }
-
 }
 
 void EFieldVolume::plot_(
@@ -145,8 +142,8 @@ void EFieldVolume::plot_(
   for (size_t index = 0; index < 3; index++) {
     const auto extract_index =
         [&index](const Eigen::Vector3d& vector) -> double {
-          return vector[static_cast<long>(index)];
-        };
+      return vector[static_cast<long>(index)];
+    };
     std::transform(points_.begin(), points_.end(),
                    std::back_inserter(rotatedPositions.at(index)),
                    extract_index);

--- a/src/EFieldVolume.cpp
+++ b/src/EFieldVolume.cpp
@@ -143,12 +143,12 @@ EFieldVolume EFieldVolume::fromBlock(const std::vector<std::string>& options) {
       continue;
     }
 
-    const auto key = tokens[0];
+    const auto key = util::tolower(tokens[0]);
     const std::vector<std::string> key_options{tokens.begin() + 1,
                                                tokens.end()};
 
     if (key == SHOW_PLOT_KEY) {
-      plot = (*key_options.begin() == "true");
+      plot = (util::tolower(*key_options.begin()) == "true");
     } else if (key == VOLUME_KEY) {
       vol = Volume::generateVolume(key_options);
     } else if (key == DENSITY_KEY) {

--- a/src/EFieldVolume.cpp
+++ b/src/EFieldVolume.cpp
@@ -17,80 +17,7 @@ namespace cpet {
 
 constexpr int DENSITY_PARAMETERS = 3;
 
-void EFieldVolume::plot(
-    const std::vector<Eigen::Vector3d>& electricField) const {
-  const auto numberOfPoints = points_.size();
-  std::array<std::vector<double>, 3> rotatedPositions;
-  std::for_each(rotatedPositions.begin(), rotatedPositions.end(),
-                [&numberOfPoints](auto& vec) { vec.reserve(numberOfPoints); });
-  std::array<std::vector<double>, 4> rotatedElectricFields;
-  std::for_each(rotatedElectricFields.begin(), rotatedElectricFields.end(),
-                [&numberOfPoints](auto& vec) { vec.reserve(numberOfPoints); });
 
-  for (size_t index = 0; index < 3; index++) {
-    const auto extract_index =
-        [&index](const Eigen::Vector3d& vector) -> double {
-      return vector[static_cast<long>(index)];
-    };
-    std::transform(points_.begin(), points_.end(),
-                   std::back_inserter(rotatedPositions.at(index)),
-                   extract_index);
-    std::transform(electricField.begin(), electricField.end(),
-                   std::back_inserter(rotatedElectricFields.at(index)),
-                   extract_index);
-  }
-
-  constexpr auto compute_magnitude =
-      [](const Eigen::Vector3d& vector) -> double { return vector.norm(); };
-  std::transform(electricField.begin(), electricField.end(),
-                 std::back_inserter(*rotatedElectricFields.rbegin()),
-                 compute_magnitude);
-
-  constexpr double vectorScale = 0.3;
-
-  matplot::quiver3(rotatedPositions[0], rotatedPositions[1],
-                   rotatedPositions[2], rotatedElectricFields[0],
-                   rotatedElectricFields[1], rotatedElectricFields[2],
-                   rotatedElectricFields[3], vectorScale)
-      ->normalize(true)
-      .line_width(2);
-  matplot::show();
-}
-
-void EFieldVolume::writeVolumeResults(
-    const std::vector<System>& systems,
-    const std::vector<std::vector<Eigen::Vector3d>>& results) const {
-  if (!output_) {
-    return;
-  }
-
-  const auto file = *output_;
-  std::ofstream outFile(file, std::ios::out);
-
-  const Eigen::IOFormat fmt(6, Eigen::DontAlignCols, " ", " ", "", "", "", "");
-  const Eigen::IOFormat commentFmt(6, 0, " ", "\n", "#", "");
-
-  if (outFile.is_open()) {
-    outFile << '#' << this->details() << '\n';
-
-    for (size_t i = 0; i < systems.size(); i++) {
-      outFile << "#Frame " << i << '\n';
-      outFile << "#Center: " << systems[i].center().transpose() << '\n';
-      outFile << "#Basis Matrix:\n"
-              << systems[i].basisMatrix().format(commentFmt) << '\n';
-
-      for (size_t j = 0; j < results[i].size(); j++) {
-        outFile << points_[j].transpose().format(fmt) << ' '
-                << results[i][j].transpose().format(fmt) << '\n';
-      }
-    }
-    outFile << std::flush;
-
-  } else {
-    SPDLOG_ERROR("Could not open file {}", file);
-    throw cpet::io_error("Could not open file " + file);
-  }
-}
 
 EFieldVolume EFieldVolume::fromSimple(const std::vector<std::string>& options) {
   constexpr bool plot = true;
@@ -184,5 +111,99 @@ EFieldVolume EFieldVolume::fromBlock(const std::vector<std::string>& options) {
   }
 
   return {std::move(vol), *density, plot, output};
+}
+
+void EFieldVolume::computeVolumeWith(const std::vector<System>& systems) const {
+  std::vector<std::vector<Eigen::Vector3d>> volumeResults;
+  volumeResults.reserve(systems.size());
+  const auto compute_volume_data = [this](const System& system) {
+    system.printCenterAndBasis();
+    auto tmpSystemResults = system.computeElectricFieldIn(*this);
+    if (showPlot_) {
+      plot_(tmpSystemResults);
+    }
+    return tmpSystemResults;
+  };
+  std::transform(systems.begin(), systems.end(),
+                 std::back_inserter(volumeResults), compute_volume_data);
+  if (output_) {
+    writeOutput_(systems, volumeResults);
+  }
+
+}
+
+void EFieldVolume::plot_(
+    const std::vector<Eigen::Vector3d>& electricField) const {
+  const auto numberOfPoints = points_.size();
+  std::array<std::vector<double>, 3> rotatedPositions;
+  std::for_each(rotatedPositions.begin(), rotatedPositions.end(),
+                [&numberOfPoints](auto& vec) { vec.reserve(numberOfPoints); });
+  std::array<std::vector<double>, 4> rotatedElectricFields;
+  std::for_each(rotatedElectricFields.begin(), rotatedElectricFields.end(),
+                [&numberOfPoints](auto& vec) { vec.reserve(numberOfPoints); });
+
+  for (size_t index = 0; index < 3; index++) {
+    const auto extract_index =
+        [&index](const Eigen::Vector3d& vector) -> double {
+          return vector[static_cast<long>(index)];
+        };
+    std::transform(points_.begin(), points_.end(),
+                   std::back_inserter(rotatedPositions.at(index)),
+                   extract_index);
+    std::transform(electricField.begin(), electricField.end(),
+                   std::back_inserter(rotatedElectricFields.at(index)),
+                   extract_index);
+  }
+
+  constexpr auto compute_magnitude =
+      [](const Eigen::Vector3d& vector) -> double { return vector.norm(); };
+  std::transform(electricField.begin(), electricField.end(),
+                 std::back_inserter(*rotatedElectricFields.rbegin()),
+                 compute_magnitude);
+
+  constexpr double vectorScale = 0.3;
+
+  matplot::quiver3(rotatedPositions[0], rotatedPositions[1],
+                   rotatedPositions[2], rotatedElectricFields[0],
+                   rotatedElectricFields[1], rotatedElectricFields[2],
+                   rotatedElectricFields[3], vectorScale)
+      ->normalize(true)
+      .line_width(2);
+  matplot::show();
+}
+
+void EFieldVolume::writeOutput_(
+    const std::vector<System>& systems,
+    const std::vector<std::vector<Eigen::Vector3d>>& results) const {
+  if (!output_) {
+    return;
+  }
+
+  const auto file = *output_;
+  std::ofstream outFile(file, std::ios::out);
+
+  const Eigen::IOFormat fmt(6, Eigen::DontAlignCols, " ", " ", "", "", "", "");
+  const Eigen::IOFormat commentFmt(6, 0, " ", "\n", "#", "");
+
+  if (outFile.is_open()) {
+    outFile << '#' << this->details() << '\n';
+
+    for (size_t i = 0; i < systems.size(); i++) {
+      outFile << "#Frame " << i << '\n';
+      outFile << "#Center: " << systems[i].center().transpose() << '\n';
+      outFile << "#Basis Matrix:\n"
+              << systems[i].basisMatrix().format(commentFmt) << '\n';
+
+      for (size_t j = 0; j < results[i].size(); j++) {
+        outFile << points_[j].transpose().format(fmt) << ' '
+                << results[i][j].transpose().format(fmt) << '\n';
+      }
+    }
+    outFile << std::flush;
+
+  } else {
+    SPDLOG_ERROR("Could not open file {}", file);
+    throw cpet::io_error("Could not open file " + file);
+  }
 }
 }  // namespace cpet

--- a/src/FieldLocations.cpp
+++ b/src/FieldLocations.cpp
@@ -57,12 +57,7 @@ FieldLocations FieldLocations::fromBlock(
   return fl;
 }
 void FieldLocations::computeEFieldsWith(
-    const std::vector<System>& systems,
-    const std::vector<std::vector<PointCharge>>& pointChargeTrajectory) const {
-  if (systems.size() != pointChargeTrajectory.size()) {
-    throw cpet::value_error(
-        "Wrong number of systems to number of point charges structures");
-  }
+    const std::vector<System>& systems) const {
 
   std::vector<std::vector<Eigen::Vector3d>> results;
   for (const auto& point : locations_) {
@@ -75,12 +70,8 @@ void FieldLocations::computeEFieldsWith(
       if (point.position()) {
         location = *(point.position());
       } else {
-        location =
-            PointCharge::find(pointChargeTrajectory[i], point)->coordinate;
-        location = systems[i].transformToUserSpace(location);
+        location = systems[i].frame().find(point)->coordinate;
       }
-
-      // systems[i].printCenterAndBasis();
 
       Eigen::Vector3d field = systems[i].electricFieldAt(location);
       SPDLOG_INFO("{} [{}]", field.transpose(), field.norm());

--- a/src/FieldLocations.cpp
+++ b/src/FieldLocations.cpp
@@ -58,7 +58,6 @@ FieldLocations FieldLocations::fromBlock(
 }
 void FieldLocations::computeEFieldsWith(
     const std::vector<System>& systems) const {
-
   std::vector<std::vector<Eigen::Vector3d>> results;
   for (const auto& point : locations_) {
     SPDLOG_INFO("=~=~=~=~[Field at {}]=~=~=~=~", point.ID());

--- a/src/FieldLocations.cpp
+++ b/src/FieldLocations.cpp
@@ -36,7 +36,7 @@ FieldLocations FieldLocations::fromBlock(
       continue;
     }
 
-    const auto key = tokens[0];
+    const auto key = util::tolower(tokens[0]);
     const std::vector<std::string> key_options{tokens.begin() + 1,
                                                tokens.end()};
 
@@ -132,7 +132,7 @@ void FieldLocations::plot_(
     figure->tiledlayout(2,2);
   }
 
-  /* can make this an option eventually 
+  /* can make this an option eventually
    figure->size(500,500); */
 
   auto current_ax = matplot::nexttile(0);
@@ -163,7 +163,7 @@ void FieldLocations::plot_(
     const auto plot = [&rotatedElectricFields, &plot_index, &current_ax, &figure](size_t index) {
       constexpr std::array<const char*, 4> titles{"X", "Y", "Z", "Magnitude"};
       current_ax = figure->nexttile(plot_index);
-      //matplot::hold(current_ax, matplot::on);
+      matplot::hold(current_ax, matplot::on);
       matplot::plot(current_ax, rotatedElectricFields.at(index));
       current_ax->xlabel("Frame");
       current_ax->ylabel("Magnitude (V/Ang)");
@@ -184,9 +184,14 @@ void FieldLocations::plot_(
       plot(3);
     }
 
-    matplot::show();
-    return;
   }
+
+  std::vector<std::string> legend_list;
+  constexpr auto get_string_representation = [](const AtomID& aid){return aid.ID();};
+  std::transform(locations_.begin(), locations_.end(), std::back_inserter(legend_list), get_string_representation);
+
+  current_ax->legend(legend_list);
+  matplot::show();
 }
 
 }  // namespace cpet

--- a/src/FieldLocations.cpp
+++ b/src/FieldLocations.cpp
@@ -1,0 +1,118 @@
+// Copyright(c) 2020-Present, Matthew R. Hennefarth
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#include "FieldLocations.h"
+
+/* EXTERNAL LIBRARY HEADER FILES */
+#include <Eigen/Dense>
+
+/* CPET HEADER FILES */
+#include "System.h"
+
+namespace cpet {
+
+FieldLocations FieldLocations::fromSimple(
+    const std::vector<std::string>& options) {
+  FieldLocations fl;
+  constexpr auto create_location = [](const std::string& location) -> AtomID {
+    return AtomID{location};
+  };
+  std::transform(options.begin(), options.end(),
+                 std::back_inserter(fl.locations_), create_location);
+  return fl;
+}
+
+FieldLocations FieldLocations::fromBlock(
+    const std::vector<std::string>& options) {
+  constexpr const char* PLOT_KEY = "plot";
+  constexpr const char* LOCATIONS_KEY = "locations";
+  constexpr const char* OUTPUT_KEY = "output";
+
+  FieldLocations fl;
+  for (const auto& line : options) {
+    const auto tokens = util::split(line, ' ');
+    if (tokens.size() < 2) {
+      continue;
+    }
+
+    const auto key = tokens[0];
+    const std::vector<std::string> key_options{tokens.begin() + 1,
+                                               tokens.end()};
+
+    if (key == LOCATIONS_KEY) {
+      constexpr auto create_location =
+          [](const std::string& location) -> AtomID {
+        return AtomID{location};
+      };
+
+      std::transform(key_options.begin(), key_options.end(),
+                     std::back_inserter(fl.locations_), create_location);
+    } else if (key == PLOT_KEY) {
+      fl.plotStyle_ = decodePlotStyle_(key_options);
+    } else if (key == OUTPUT_KEY) {
+      fl.output_ = *key_options.begin();
+    }
+  }
+  return fl;
+}
+void FieldLocations::computeEFieldsWith(
+    const std::vector<System>& systems,
+    const std::vector<std::vector<PointCharge>>& pointChargeTrajectory) const {
+  if (systems.size() != pointChargeTrajectory.size()) {
+    throw cpet::value_error(
+        "Wrong number of systems to number of point charges structures");
+  }
+
+  std::vector<std::vector<Eigen::Vector3d>> results;
+  for (const auto& point : locations_) {
+    SPDLOG_INFO("=~=~=~=~[Field at {}]=~=~=~=~", point.ID());
+    std::vector<Eigen::Vector3d> fieldTrajectoryAtPoint;
+
+    for (size_t i = 0; i < systems.size(); i++) {
+      Eigen::Vector3d location;
+
+      if (point.position()) {
+        location = *(point.position());
+      } else {
+        location =
+            PointCharge::find(pointChargeTrajectory[i], point)->coordinate;
+        location = systems[i].transformToUserSpace(location);
+      }
+
+      // systems[i].printCenterAndBasis();
+
+      Eigen::Vector3d field = systems[i].electricFieldAt(location);
+      SPDLOG_INFO("{} [{}]", field.transpose(), field.norm());
+      fieldTrajectoryAtPoint.emplace_back(field);
+    }
+    results.push_back(fieldTrajectoryAtPoint);
+  }
+  if (output_) {
+    writeOutput_(results);
+  }
+  if (showPlots()) {
+    // plot_(results);
+  }
+}
+void FieldLocations::writeOutput_(
+    const std::vector<std::vector<Eigen::Vector3d>>& results) const {
+  if (!output_) {
+    return;
+  }
+
+  std::ofstream outFile(*output_, std::ios::out);
+  if (outFile.is_open()) {
+    for (size_t i = 0; i < results.size(); i++) {
+      outFile << '#' << locations_[i].ID() << '\n';
+      for (const Eigen::Vector3d& field : results[i]) {
+        outFile << field.transpose() << '\n';
+      }
+    }
+    outFile << std::flush;
+  } else {
+    SPDLOG_ERROR("Could not open file {}", *output_);
+    throw cpet::io_error("Could not open file " + *output_);
+  }
+}
+
+}  // namespace cpet

--- a/src/FieldLocations.cpp
+++ b/src/FieldLocations.cpp
@@ -117,19 +117,19 @@ void FieldLocations::writeOutput_(
 }
 void FieldLocations::plot_(
     const std::vector<std::vector<Eigen::Vector3d>>& results) const {
-
-  const auto numberOfPlots = util::countSetBits(static_cast<unsigned int>(plotStyle_));
+  const auto numberOfPlots =
+      util::countSetBits(static_cast<unsigned int>(plotStyle_));
   if (numberOfPlots <= 0 || numberOfPlots > 4) {
-    SPDLOG_WARN("Number of plots less than 1 or greater than 4! Error in logic");
+    SPDLOG_WARN(
+        "Number of plots less than 1 or greater than 4! Error in logic");
     return;
   }
-
 
   auto figure = matplot::figure();
   if (numberOfPlots < 3) {
     figure->tiledlayout(numberOfPlots, 1);
   } else {
-    figure->tiledlayout(2,2);
+    figure->tiledlayout(2, 2);
   }
 
   /* can make this an option eventually
@@ -137,13 +137,13 @@ void FieldLocations::plot_(
 
   auto current_ax = matplot::nexttile(0);
 
-  for(const auto& data : results) {
+  for (const auto& data : results) {
     std::array<std::vector<double>, 4> rotatedElectricFields;
     for (size_t index = 0; index < 3; index++) {
       const auto extract_index =
           [&index](const Eigen::Vector3d& vector) -> double {
-            return vector[static_cast<long>(index)];
-          };
+        return vector[static_cast<long>(index)];
+      };
 
       std::transform(data.begin(), data.end(),
                      std::back_inserter(rotatedElectricFields.at(index)),
@@ -159,8 +159,9 @@ void FieldLocations::plot_(
 
     size_t plot_index = 0;
 
-    //constexpr std::array<const char*, 4> titles{"X", "Y", "Z", "Magnitude"};
-    const auto plot = [&rotatedElectricFields, &plot_index, &current_ax, &figure](size_t index) {
+    // constexpr std::array<const char*, 4> titles{"X", "Y", "Z", "Magnitude"};
+    const auto plot = [&rotatedElectricFields, &plot_index, &current_ax,
+                       &figure](size_t index) {
       constexpr std::array<const char*, 4> titles{"X", "Y", "Z", "Magnitude"};
       current_ax = figure->nexttile(plot_index);
       matplot::hold(current_ax, matplot::on);
@@ -183,12 +184,14 @@ void FieldLocations::plot_(
     if (plotM_()) {
       plot(3);
     }
-
   }
 
   std::vector<std::string> legend_list;
-  constexpr auto get_string_representation = [](const AtomID& aid){return aid.ID();};
-  std::transform(locations_.begin(), locations_.end(), std::back_inserter(legend_list), get_string_representation);
+  constexpr auto get_string_representation = [](const AtomID& aid) {
+    return aid.ID();
+  };
+  std::transform(locations_.begin(), locations_.end(),
+                 std::back_inserter(legend_list), get_string_representation);
 
   current_ax->legend(legend_list);
   matplot::show();

--- a/src/Option.cpp
+++ b/src/Option.cpp
@@ -103,21 +103,28 @@ void Option::loadOptionsDataFromFile_(const std::string& optionFile) {
 }
 
 void Option::parseSimpleOptions_() {
+  const std::unordered_map<std::string,
+                           void (Option::*)(const std::vector<std::string>&)>
+      parseSimpleOptionsMap = {{ALIGN_KEY, &Option::parseAlignSimple_},
+                               {TOPOLOGY_KEY, &Option::parseTopologySimple_},
+                               {FIELD_KEY, &Option::parseFieldSimple_},
+                               {PLOT_3D_KEY, &Option::parsePlot3dSimple_}};
+
   SPDLOG_DEBUG("Parsing simple options");
 
   std::for_each(simpleOptions_.begin(), simpleOptions_.end(),
-                [this](const auto& line) {
+                [this, &parseSimpleOptionsMap](const auto& line) {
                   const std::vector<std::string> info = util::split(line, ' ');
                   if (info.empty()) {
                     return;
                   }
 
-                  const auto key = info.at(0);
+                  const auto key = util::tolower(info.at(0));
                   const std::vector<std::string> key_options{info.begin() + 1,
                                                              info.end()};
 
-                  if (const auto func = parseSimpleOptionsMap_.find(key);
-                      func == parseSimpleOptionsMap_.end()) {
+                  if (const auto func = parseSimpleOptionsMap.find(key);
+                      func == parseSimpleOptionsMap.end()) {
                     SPDLOG_WARN("Unknown key in simple options {}", key);
                   } else {
                     (this->*(func->second))(key_options);
@@ -126,9 +133,14 @@ void Option::parseSimpleOptions_() {
 }
 void Option::parseBlockOptions_() {
   SPDLOG_DEBUG("Parsing block options");
+  const std::unordered_map<std::string,
+                           void (Option::*)(const std::vector<std::string>&)>
+      parseBlockOptionsMap = {{PLOT_3D_KEY, &Option::parsePlot3dBlock_},
+                              {FIELD_KEY, &Option::parseFieldBlock_}};
+
   for (const auto& [key, lines] : blockOptions_) {
-    if (const auto func = parseBlockOptionsMap_.find(key);
-        func == parseBlockOptionsMap_.end()) {
+    if (const auto func = parseBlockOptionsMap.find(util::tolower(key));
+        func == parseBlockOptionsMap.end()) {
       SPDLOG_WARN("Unknown key in block options {}", key);
     } else {
       (this->*(func->second))(lines);

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -17,7 +17,8 @@
 
 namespace cpet {
 
-System::System(const Frame& frame, const Option& options) : frame_(frame), pointCharges_(frame_.begin(), frame_.end()) {
+System::System(const Frame& frame, const Option& options)
+    : frame_(frame), pointCharges_(frame_.begin(), frame_.end()) {
   if (options.centerID.position()) {
     center_ = *(options.centerID.position());
   } else {
@@ -79,7 +80,6 @@ System::System(const Frame& frame, const Option& options) : frame_(frame), point
   pointCharges_.erase(remove_if(begin(pointCharges_), end(pointCharges_),
                                 [](const auto& p) { return p.charge == 0.0; }),
                       end(pointCharges_));
-
 }
 
 Eigen::Vector3d System::electricFieldAt(const Eigen::Vector3d& position) const {

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -17,12 +17,11 @@
 
 namespace cpet {
 
-System::System(std::vector<PointCharge> pc, const Option& options)
-    : pointCharges_(std::move(pc)) {
+System::System(const Frame& frame, const Option& options) : frame_(frame), pointCharges_(frame_.begin(), frame_.end()) {
   if (options.centerID.position()) {
     center_ = *(options.centerID.position());
   } else {
-    center_ = PointCharge::find(pointCharges_, options.centerID)->coordinate;
+    center_ = frame_.find(options.centerID)->coordinate;
   }
 
   std::array<Eigen::Vector3d, 3> basis;
@@ -36,9 +35,7 @@ System::System(std::vector<PointCharge> pc, const Option& options)
       basis[0] = *(options.direction1ID.position()) - center_;
     }
   } else {
-    basis[0] =
-        PointCharge::find(pointCharges_, options.direction1ID)->coordinate -
-        center_;
+    basis[0] = frame_.find(options.direction1ID)->coordinate - center_;
   }
   SPDLOG_DEBUG("Basis[0] is {}", basis[0].transpose());
   basis[0] = basis[0] / basis[0].norm();
@@ -53,9 +50,7 @@ System::System(std::vector<PointCharge> pc, const Option& options)
       basis[1] = *(options.direction2ID.position()) - center_;
     }
   } else {
-    basis[1] =
-        PointCharge::find(pointCharges_, options.direction2ID)->coordinate -
-        center_;
+    basis[1] = frame_.find(options.direction2ID)->coordinate - center_;
   }
   SPDLOG_DEBUG("Basis[1] is {}", basis[1].transpose());
   basis[1] = basis[1] / basis[1].norm();
@@ -84,6 +79,7 @@ System::System(std::vector<PointCharge> pc, const Option& options)
   pointCharges_.erase(remove_if(begin(pointCharges_), end(pointCharges_),
                                 [](const auto& p) { return p.charge == 0.0; }),
                       end(pointCharges_));
+
 }
 
 Eigen::Vector3d System::electricFieldAt(const Eigen::Vector3d& position) const {

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -19,39 +19,39 @@ namespace cpet {
 
 System::System(const Frame& frame, const Option& options)
     : frame_(frame), pointCharges_(frame_.begin(), frame_.end()) {
-  if (options.centerID.position()) {
-    center_ = *(options.centerID.position());
+  if (options.centerID().position()) {
+    center_ = *(options.centerID().position());
   } else {
-    center_ = frame_.find(options.centerID)->coordinate;
+    center_ = frame_.find(options.centerID())->coordinate;
   }
 
   std::array<Eigen::Vector3d, 3> basis;
 
-  if (options.direction1ID.position()) {
-    if (options.direction1ID.isConstant()) {
+  if (options.direction1ID().position()) {
+    if (options.direction1ID().isConstant()) {
       SPDLOG_DEBUG("Using constant direction for direction 1");
-      basis[0] = *(options.direction1ID.position());
+      basis[0] = *(options.direction1ID().position());
     } else {
       SPDLOG_DEBUG("Using user defined vector for direction 1");
-      basis[0] = *(options.direction1ID.position()) - center_;
+      basis[0] = *(options.direction1ID().position()) - center_;
     }
   } else {
-    basis[0] = frame_.find(options.direction1ID)->coordinate - center_;
+    basis[0] = frame_.find(options.direction1ID())->coordinate - center_;
   }
   SPDLOG_DEBUG("Basis[0] is {}", basis[0].transpose());
   basis[0] = basis[0] / basis[0].norm();
   SPDLOG_DEBUG("Normalized, basis[0] is {}", basis[0].transpose());
 
-  if (options.direction2ID.position()) {
-    if (options.direction2ID.isConstant()) {
+  if (options.direction2ID().position()) {
+    if (options.direction2ID().isConstant()) {
       SPDLOG_DEBUG("Using constant direction for direction 2");
-      basis[1] = *(options.direction2ID.position());
+      basis[1] = *(options.direction2ID().position());
     } else {
       SPDLOG_DEBUG("Using user defined vector for direction 2");
-      basis[1] = *(options.direction2ID.position()) - center_;
+      basis[1] = *(options.direction2ID().position()) - center_;
     }
   } else {
-    basis[1] = frame_.find(options.direction2ID)->coordinate - center_;
+    basis[1] = frame_.find(options.direction2ID())->coordinate - center_;
   }
   SPDLOG_DEBUG("Basis[1] is {}", basis[1].transpose());
   basis[1] = basis[1] / basis[1].norm();

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -7,6 +7,7 @@
 #else
   #include <numeric>
 #endif
+#include <sstream>
 
 /* CPET HEADER FILES */
 #include "Utilities.h"
@@ -26,7 +27,7 @@ void forEachLineIn(const std::string& file,
   }
 }
 
-std::vector<std::string> split(std::string_view str, char delim) {
+std::vector<std::string> split(const std::string_view str, char delim) {
   std::vector<std::string> result;
 
   std::string::size_type start = 0;

--- a/src/Volume.cpp
+++ b/src/Volume.cpp
@@ -31,7 +31,7 @@ std::unique_ptr<Volume> makeBox(const std::vector<std::string>& options) {
 }
 
 std::unique_ptr<Volume> Volume::generateVolume(
-    std::vector<std::string> options) {
+   const std::vector<std::string>& options) {
   static const std::unordered_map<
       std::string,
       std::function<std::unique_ptr<Volume>(const std::vector<std::string>&)>>

--- a/src/Volume.cpp
+++ b/src/Volume.cpp
@@ -31,7 +31,7 @@ std::unique_ptr<Volume> makeBox(const std::vector<std::string>& options) {
 }
 
 std::unique_ptr<Volume> Volume::generateVolume(
-   const std::vector<std::string>& options) {
+    const std::vector<std::string>& options) {
   static const std::unordered_map<
       std::string,
       std::function<std::unique_ptr<Volume>(const std::vector<std::string>&)>>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories( ${PROJECT_SOURCE_DIR}/include )
 
 add_executable(runUnitTests test_utilities.cpp test_volume.cpp test_pointcharges.cpp test_option.cpp test_system.cpp 
-  ../src/Utilities.cpp ../src/Option.cpp ../src/System.cpp ../src/EFieldVolume.cpp ../src/Volume.cpp)
+  ../src/Utilities.cpp ../src/Option.cpp ../src/System.cpp ../src/EFieldVolume.cpp ../src/Volume.cpp ../src/FieldLocations.cpp)
 set_target_properties( runUnitTests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/Testing )
 target_compile_definitions(runUnitTests PRIVATE -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_OFF)
 

--- a/tests/Data/invalid_options/field_block_invalidplot
+++ b/tests/Data/invalid_options/field_block_invalidplot
@@ -1,0 +1,4 @@
+%field
+  locations A:76:d
+  plot x a y
+end

--- a/tests/Data/valid_options/align_triple
+++ b/tests/Data/valid_options/align_triple
@@ -1,3 +1,2 @@
 align 1:3:1 D:54:CG D:56:SG
-field 54:55:34
-field D:5:C100
+field 54:55:34 D:5:C100

--- a/tests/Data/valid_options/field_2block_valid
+++ b/tests/Data/valid_options/field_2block_valid
@@ -1,0 +1,13 @@
+align A:45:C11
+
+%field
+  locations 1:2:1
+  plot x y
+  output
+end
+
+%field
+  locations C:126:SG 45:64:3
+  plot      
+  output   2locations.data
+end

--- a/tests/Data/valid_options/field_block_nolocations
+++ b/tests/Data/valid_options/field_block_nolocations
@@ -1,0 +1,3 @@
+%field
+  plot x y 
+end

--- a/tests/Data/valid_options/field_block_valid
+++ b/tests/Data/valid_options/field_block_valid
@@ -1,0 +1,7 @@
+align 0:1:0
+
+%field
+  locations 1:2:1 A:45:C001
+  plot x m
+  output fields_ab
+end

--- a/tests/test_option.cpp
+++ b/tests/test_option.cpp
@@ -319,3 +319,21 @@ TEST(Option, Field2BlockValid) {
   ASSERT_TRUE(fl2.output());
   EXPECT_EQ(*fl2.output(), "2locations.data");
 }
+
+TEST(Option, FieldBlockNoLocations){
+  std::string options_file = "Data/valid_options/field_block_nolocations";
+  ASSERT_TRUE(std::filesystem::exists(options_file));
+
+  cpet::Option option;
+  ASSERT_NO_THROW(option = cpet::Option{options_file});
+  EXPECT_EQ(option.calculateFieldLocations().size(), 1);
+  EXPECT_TRUE(option.calculateFieldLocations()[0].locations().empty());
+}
+
+TEST(Option, FieldBlockInvalidPlot){
+  std::string options_file = "Data/invalid_options/field_block_invalidplot";
+  ASSERT_TRUE(std::filesystem::exists(options_file));
+
+  cpet::Option option;
+  ASSERT_THROW(option = cpet::Option{options_file}, cpet::invalid_option);
+}

--- a/tests/test_option.cpp
+++ b/tests/test_option.cpp
@@ -126,7 +126,7 @@ TEST(Option, ValidTopoBox) {
   EXPECT_TRUE(option.calculateEFieldVolumes().empty());
 
   ASSERT_EQ(option.calculateEFieldTopology().size(), 1);
-  const auto *tr1 = &option.calculateEFieldTopology()[0];
+  const auto* tr1 = &option.calculateEFieldTopology()[0];
 
   EXPECT_EQ(tr1->numberOfSamples, 10);
   EXPECT_EQ(tr1->volume->type(), "box");
@@ -154,7 +154,7 @@ TEST(Option, ValidTopoBoxAlign) {
   EXPECT_TRUE(option.calculateEFieldVolumes().empty());
 
   ASSERT_EQ(option.calculateEFieldTopology().size(), 1);
-  const auto *tr1 = &option.calculateEFieldTopology()[0];
+  const auto* tr1 = &option.calculateEFieldTopology()[0];
 
   EXPECT_EQ(tr1->numberOfSamples, 100000);
   EXPECT_EQ(tr1->volume->type(), "box");

--- a/tests/test_option.cpp
+++ b/tests/test_option.cpp
@@ -9,6 +9,7 @@
 #include "Exceptions.h"
 #include "Option.h"
 #include "EFieldVolume.h"
+#include "FieldLocations.h"
 
 TEST(Option, SimpleField) {
   ASSERT_TRUE(std::filesystem::exists("Data/valid_options/simple_field"));
@@ -28,8 +29,10 @@ TEST(Option, SimpleField) {
   EXPECT_TRUE(option.calculateEFieldTopology.empty());
   EXPECT_TRUE(option.calculateEFieldVolumes.empty());
 
-  ASSERT_EQ(option.calculateEFieldPoints.size(), 1);
-  EXPECT_EQ(option.calculateEFieldPoints[0], "0:0:0");
+  ASSERT_EQ(option.calculateFieldLocations().size(), 1);
+  auto fl = option.calculateFieldLocations()[0];
+  ASSERT_EQ(fl.locations().size(), 1);
+  EXPECT_EQ(fl.locations()[0], "0:0:0");
 }
 
 TEST(Option, AlignZero) {
@@ -59,8 +62,10 @@ TEST(Option, AlignSingle) {
   EXPECT_TRUE(option.calculateEFieldTopology.empty());
   EXPECT_TRUE(option.calculateEFieldVolumes.empty());
 
-  ASSERT_EQ(option.calculateEFieldPoints.size(), 1);
-  EXPECT_EQ(option.calculateEFieldPoints[0], "5:4:2");
+  ASSERT_EQ(option.calculateFieldLocations().size(), 1);
+  auto fl = option.calculateFieldLocations()[0];
+  ASSERT_EQ(fl.locations().size(), 1);
+  EXPECT_EQ(fl.locations()[0], "5:4:2");
 }
 
 TEST(Option, AlignDouble) {
@@ -94,9 +99,11 @@ TEST(Option, AlignTriple) {
   EXPECT_TRUE(option.calculateEFieldTopology.empty());
   EXPECT_TRUE(option.calculateEFieldVolumes.empty());
 
-  ASSERT_EQ(option.calculateEFieldPoints.size(), 2);
-  EXPECT_EQ(option.calculateEFieldPoints[0], "54:55:34");
-  EXPECT_EQ(option.calculateEFieldPoints[1], "D:5:C100");
+  ASSERT_EQ(option.calculateFieldLocations().size(), 1);
+  auto fl = option.calculateFieldLocations()[0];
+  ASSERT_EQ(fl.locations().size(), 2);
+  EXPECT_EQ(fl.locations()[0], "54:55:34");
+  EXPECT_EQ(fl.locations()[1], "D:5:C100");
 }
 
 TEST(Option, ValidTopoBox) {
@@ -115,7 +122,7 @@ TEST(Option, ValidTopoBox) {
   EXPECT_TRUE(option.direction2ID.isConstant());
   EXPECT_EQ(option.direction2ID, cpet::AtomID::Constants::e2);
 
-  EXPECT_TRUE(option.calculateEFieldPoints.empty());
+  EXPECT_TRUE(option.calculateFieldLocations().empty());
   EXPECT_TRUE(option.calculateEFieldVolumes.empty());
 
   ASSERT_EQ(option.calculateEFieldTopology.size(), 1);
@@ -143,7 +150,7 @@ TEST(Option, ValidTopoBoxAlign) {
   EXPECT_TRUE(option.direction2ID.isConstant());
   EXPECT_EQ(option.direction2ID, cpet::AtomID::Constants::e2);
 
-  EXPECT_TRUE(option.calculateEFieldPoints.empty());
+  EXPECT_TRUE(option.calculateFieldLocations().empty());
   EXPECT_TRUE(option.calculateEFieldVolumes.empty());
 
   ASSERT_EQ(option.calculateEFieldTopology.size(), 1);
@@ -195,7 +202,7 @@ TEST(Option, Plot3DSimpleValid) {
 
   EXPECT_FALSE(efv.output());
 
-  EXPECT_TRUE(option.calculateEFieldPoints.empty());
+  EXPECT_TRUE(option.calculateFieldLocations().empty());
   EXPECT_TRUE(option.calculateEFieldTopology.empty());
 }
 
@@ -250,4 +257,28 @@ TEST(Option, InvalidPlot3dBlockNoVolume) {
   std::string options_file = "Data/invalid_options/plot3d_block_novolume";
   ASSERT_TRUE(std::filesystem::exists(options_file));
   EXPECT_THROW(auto o = cpet::Option{options_file}, cpet::invalid_option);
+}
+
+TEST(Option, FieldBlockValid) {
+  std::string options_file = "Data/valid_options/field_block_valid";
+  ASSERT_TRUE(std::filesystem::exists(options_file));
+
+  cpet::Option option;
+  ASSERT_NO_THROW(option = cpet::Option{options_file});
+
+  ASSERT_EQ(option.calculateFieldLocations().size(), 1);
+  auto fl = option.calculateFieldLocations()[0];
+
+  ASSERT_EQ(fl.locations().size(), 2);
+
+  cpet::PlotStyles plotstyle = fl.plotStyle();
+  EXPECT_TRUE(fl.showPlots());
+  EXPECT_TRUE((plotstyle & cpet::PlotStyles::x) == cpet::PlotStyles::x);
+  EXPECT_TRUE((plotstyle & cpet::PlotStyles::m) == cpet::PlotStyles::m);
+  EXPECT_FALSE((plotstyle & cpet::PlotStyles::y) == cpet::PlotStyles::y);
+  EXPECT_FALSE((plotstyle & cpet::PlotStyles::z) == cpet::PlotStyles::z);
+  EXPECT_TRUE(fl.output());
+
+  EXPECT_EQ(*fl.output(), "fields_ab");
+
 }

--- a/tests/test_option.cpp
+++ b/tests/test_option.cpp
@@ -282,3 +282,40 @@ TEST(Option, FieldBlockValid) {
   EXPECT_EQ(*fl.output(), "fields_ab");
 
 }
+
+TEST(Option, Field2BlockValid) {
+  std::string options_file = "Data/valid_options/field_2block_valid";
+  ASSERT_TRUE(std::filesystem::exists(options_file));
+
+  cpet::Option option;
+  ASSERT_NO_THROW(option = cpet::Option{options_file});
+
+  ASSERT_EQ(option.calculateFieldLocations().size(), 2);
+  auto fl1 = option.calculateFieldLocations()[0];
+
+  ASSERT_EQ(fl1.locations().size(), 1);
+  EXPECT_EQ(fl1.locations()[0], "1:2:1");
+
+  cpet::PlotStyles plotstyle = fl1.plotStyle();
+  EXPECT_TRUE(fl1.showPlots());
+  EXPECT_TRUE((plotstyle & cpet::PlotStyles::x) == cpet::PlotStyles::x);
+  EXPECT_TRUE((plotstyle & cpet::PlotStyles::y) == cpet::PlotStyles::y);
+  EXPECT_FALSE((plotstyle & cpet::PlotStyles::m) == cpet::PlotStyles::m);
+  EXPECT_FALSE((plotstyle & cpet::PlotStyles::z) == cpet::PlotStyles::z);
+  EXPECT_FALSE(fl1.output());
+
+  auto fl2 = option.calculateFieldLocations()[1];
+  ASSERT_EQ(fl2.locations().size(), 2);
+  EXPECT_EQ(fl2.locations()[0], "C:126:SG");
+  EXPECT_EQ(fl2.locations()[1], "45:64:3");
+
+  plotstyle = fl2.plotStyle();
+  EXPECT_FALSE(fl2.showPlots());
+  EXPECT_FALSE((plotstyle & cpet::PlotStyles::x) == cpet::PlotStyles::x);
+  EXPECT_FALSE((plotstyle & cpet::PlotStyles::y) == cpet::PlotStyles::y);
+  EXPECT_FALSE((plotstyle & cpet::PlotStyles::m) == cpet::PlotStyles::m);
+  EXPECT_FALSE((plotstyle & cpet::PlotStyles::z) == cpet::PlotStyles::z);
+
+  ASSERT_TRUE(fl2.output());
+  EXPECT_EQ(*fl2.output(), "2locations.data");
+}

--- a/tests/test_option.cpp
+++ b/tests/test_option.cpp
@@ -280,7 +280,6 @@ TEST(Option, FieldBlockValid) {
   EXPECT_TRUE(fl.output());
 
   EXPECT_EQ(*fl.output(), "fields_ab");
-
 }
 
 TEST(Option, Field2BlockValid) {
@@ -320,7 +319,7 @@ TEST(Option, Field2BlockValid) {
   EXPECT_EQ(*fl2.output(), "2locations.data");
 }
 
-TEST(Option, FieldBlockNoLocations){
+TEST(Option, FieldBlockNoLocations) {
   std::string options_file = "Data/valid_options/field_block_nolocations";
   ASSERT_TRUE(std::filesystem::exists(options_file));
 
@@ -330,7 +329,7 @@ TEST(Option, FieldBlockNoLocations){
   EXPECT_TRUE(option.calculateFieldLocations()[0].locations().empty());
 }
 
-TEST(Option, FieldBlockInvalidPlot){
+TEST(Option, FieldBlockInvalidPlot) {
   std::string options_file = "Data/invalid_options/field_block_invalidplot";
   ASSERT_TRUE(std::filesystem::exists(options_file));
 

--- a/tests/test_option.cpp
+++ b/tests/test_option.cpp
@@ -26,8 +26,8 @@ TEST(Option, SimpleField) {
   EXPECT_TRUE(option.direction2ID.isConstant());
   EXPECT_EQ(option.direction2ID, cpet::AtomID::Constants::e2);
 
-  EXPECT_TRUE(option.calculateEFieldTopology.empty());
-  EXPECT_TRUE(option.calculateEFieldVolumes.empty());
+  EXPECT_TRUE(option.calculateEFieldTopology().empty());
+  EXPECT_TRUE(option.calculateEFieldVolumes().empty());
 
   ASSERT_EQ(option.calculateFieldLocations().size(), 1);
   auto fl = option.calculateFieldLocations()[0];
@@ -59,8 +59,8 @@ TEST(Option, AlignSingle) {
   EXPECT_TRUE(option.direction2ID.isConstant());
   EXPECT_EQ(option.direction2ID, cpet::AtomID::Constants::e2);
 
-  EXPECT_TRUE(option.calculateEFieldTopology.empty());
-  EXPECT_TRUE(option.calculateEFieldVolumes.empty());
+  EXPECT_TRUE(option.calculateEFieldTopology().empty());
+  EXPECT_TRUE(option.calculateEFieldVolumes().empty());
 
   ASSERT_EQ(option.calculateFieldLocations().size(), 1);
   auto fl = option.calculateFieldLocations()[0];
@@ -96,8 +96,8 @@ TEST(Option, AlignTriple) {
   EXPECT_FALSE(option.direction2ID.isVector());
   EXPECT_EQ(option.direction2ID, "D:56:SG");
 
-  EXPECT_TRUE(option.calculateEFieldTopology.empty());
-  EXPECT_TRUE(option.calculateEFieldVolumes.empty());
+  EXPECT_TRUE(option.calculateEFieldTopology().empty());
+  EXPECT_TRUE(option.calculateEFieldVolumes().empty());
 
   ASSERT_EQ(option.calculateFieldLocations().size(), 1);
   auto fl = option.calculateFieldLocations()[0];
@@ -123,10 +123,10 @@ TEST(Option, ValidTopoBox) {
   EXPECT_EQ(option.direction2ID, cpet::AtomID::Constants::e2);
 
   EXPECT_TRUE(option.calculateFieldLocations().empty());
-  EXPECT_TRUE(option.calculateEFieldVolumes.empty());
+  EXPECT_TRUE(option.calculateEFieldVolumes().empty());
 
-  ASSERT_EQ(option.calculateEFieldTopology.size(), 1);
-  auto tr1 = &option.calculateEFieldTopology[0];
+  ASSERT_EQ(option.calculateEFieldTopology().size(), 1);
+  auto tr1 = &option.calculateEFieldTopology()[0];
 
   EXPECT_EQ(tr1->numberOfSamples, 10);
   EXPECT_EQ(tr1->volume->type(), "box");
@@ -151,10 +151,10 @@ TEST(Option, ValidTopoBoxAlign) {
   EXPECT_EQ(option.direction2ID, cpet::AtomID::Constants::e2);
 
   EXPECT_TRUE(option.calculateFieldLocations().empty());
-  EXPECT_TRUE(option.calculateEFieldVolumes.empty());
+  EXPECT_TRUE(option.calculateEFieldVolumes().empty());
 
-  ASSERT_EQ(option.calculateEFieldTopology.size(), 1);
-  auto tr1 = &option.calculateEFieldTopology[0];
+  ASSERT_EQ(option.calculateEFieldTopology().size(), 1);
+  auto tr1 = &option.calculateEFieldTopology()[0];
 
   EXPECT_EQ(tr1->numberOfSamples, 100000);
   EXPECT_EQ(tr1->volume->type(), "box");
@@ -189,9 +189,9 @@ TEST(Option, Plot3DSimpleValid) {
 
   cpet::Option option;
   ASSERT_NO_THROW(option = cpet::Option{options_file});
-  ASSERT_EQ(option.calculateEFieldVolumes.size(), 1);
+  ASSERT_EQ(option.calculateEFieldVolumes().size(), 1);
 
-  cpet::EFieldVolume& efv = option.calculateEFieldVolumes[0];
+  const cpet::EFieldVolume& efv = option.calculateEFieldVolumes()[0];
 
   EXPECT_TRUE(efv.showPlot());
   EXPECT_FALSE(efv.points().empty());
@@ -203,7 +203,7 @@ TEST(Option, Plot3DSimpleValid) {
   EXPECT_FALSE(efv.output());
 
   EXPECT_TRUE(option.calculateFieldLocations().empty());
-  EXPECT_TRUE(option.calculateEFieldTopology.empty());
+  EXPECT_TRUE(option.calculateEFieldTopology().empty());
 }
 
 TEST(Option, Plot3DSimpleBoxInvalid_5Params) {
@@ -219,10 +219,10 @@ TEST(Option, Plot3dBlockBoxValid) {
 
   cpet::Option option;
   ASSERT_NO_THROW(option = cpet::Option{options_file});
-  ASSERT_EQ(option.calculateEFieldVolumes.size(), 2);
+  ASSERT_EQ(option.calculateEFieldVolumes().size(), 2);
 
-  cpet::EFieldVolume& efv0 = option.calculateEFieldVolumes[0];
-  cpet::EFieldVolume& efv1 = option.calculateEFieldVolumes[1];
+  const cpet::EFieldVolume& efv0 = option.calculateEFieldVolumes()[0];
+  const cpet::EFieldVolume& efv1 = option.calculateEFieldVolumes()[1];
 
   EXPECT_TRUE(efv0.showPlot());
   EXPECT_FALSE(efv1.showPlot());

--- a/tests/test_option.cpp
+++ b/tests/test_option.cpp
@@ -17,14 +17,14 @@ TEST(Option, SimpleField) {
   cpet::Option option;
   ASSERT_NO_THROW(option = cpet::Option{"Data/valid_options/simple_field"});
 
-  EXPECT_TRUE(option.centerID.isConstant());
-  EXPECT_EQ(option.centerID, cpet::AtomID::Constants::origin);
+  EXPECT_TRUE(option.centerID().isConstant());
+  EXPECT_EQ(option.centerID(), cpet::AtomID::Constants::origin);
 
-  EXPECT_TRUE(option.direction1ID.isConstant());
-  EXPECT_EQ(option.direction1ID, cpet::AtomID::Constants::e1);
+  EXPECT_TRUE(option.direction1ID().isConstant());
+  EXPECT_EQ(option.direction1ID(), cpet::AtomID::Constants::e1);
 
-  EXPECT_TRUE(option.direction2ID.isConstant());
-  EXPECT_EQ(option.direction2ID, cpet::AtomID::Constants::e2);
+  EXPECT_TRUE(option.direction2ID().isConstant());
+  EXPECT_EQ(option.direction2ID(), cpet::AtomID::Constants::e2);
 
   EXPECT_TRUE(option.calculateEFieldTopology().empty());
   EXPECT_TRUE(option.calculateEFieldVolumes().empty());
@@ -47,17 +47,17 @@ TEST(Option, AlignSingle) {
   cpet::Option option;
   ASSERT_NO_THROW(option = cpet::Option{"Data/valid_options/align_single"});
 
-  EXPECT_FALSE(option.centerID.isConstant());
-  EXPECT_TRUE(option.centerID.isVector());
+  EXPECT_FALSE(option.centerID().isConstant());
+  EXPECT_TRUE(option.centerID().isVector());
   Eigen::Vector3d center{1, 0, 0};
-  ASSERT_TRUE(option.centerID.position());
-  EXPECT_NEAR((*option.centerID.position() - center).norm(), 0.0, 0.0001);
+  ASSERT_TRUE(option.centerID().position());
+  EXPECT_NEAR((*option.centerID().position() - center).norm(), 0.0, 0.0001);
 
-  EXPECT_TRUE(option.direction1ID.isConstant());
-  EXPECT_EQ(option.direction1ID, cpet::AtomID::Constants::e1);
+  EXPECT_TRUE(option.direction1ID().isConstant());
+  EXPECT_EQ(option.direction1ID(), cpet::AtomID::Constants::e1);
 
-  EXPECT_TRUE(option.direction2ID.isConstant());
-  EXPECT_EQ(option.direction2ID, cpet::AtomID::Constants::e2);
+  EXPECT_TRUE(option.direction2ID().isConstant());
+  EXPECT_EQ(option.direction2ID(), cpet::AtomID::Constants::e2);
 
   EXPECT_TRUE(option.calculateEFieldTopology().empty());
   EXPECT_TRUE(option.calculateEFieldVolumes().empty());
@@ -82,19 +82,19 @@ TEST(Option, AlignTriple) {
   cpet::Option option;
   ASSERT_NO_THROW(option = cpet::Option{options_file});
 
-  EXPECT_FALSE(option.centerID.isConstant());
-  EXPECT_TRUE(option.centerID.isVector());
+  EXPECT_FALSE(option.centerID().isConstant());
+  EXPECT_TRUE(option.centerID().isVector());
   Eigen::Vector3d center{1, 3, 1};
-  ASSERT_TRUE(option.centerID.position());
-  EXPECT_NEAR((*option.centerID.position() - center).norm(), 0.0, 0.0001);
+  ASSERT_TRUE(option.centerID().position());
+  EXPECT_NEAR((*option.centerID().position() - center).norm(), 0.0, 0.0001);
 
-  EXPECT_FALSE(option.direction1ID.isConstant());
-  EXPECT_FALSE(option.direction1ID.isVector());
-  EXPECT_EQ(option.direction1ID, "D:54:CG");
+  EXPECT_FALSE(option.direction1ID().isConstant());
+  EXPECT_FALSE(option.direction1ID().isVector());
+  EXPECT_EQ(option.direction1ID(), "D:54:CG");
 
-  EXPECT_FALSE(option.direction2ID.isConstant());
-  EXPECT_FALSE(option.direction2ID.isVector());
-  EXPECT_EQ(option.direction2ID, "D:56:SG");
+  EXPECT_FALSE(option.direction2ID().isConstant());
+  EXPECT_FALSE(option.direction2ID().isVector());
+  EXPECT_EQ(option.direction2ID(), "D:56:SG");
 
   EXPECT_TRUE(option.calculateEFieldTopology().empty());
   EXPECT_TRUE(option.calculateEFieldVolumes().empty());
@@ -113,20 +113,20 @@ TEST(Option, ValidTopoBox) {
   cpet::Option option;
   ASSERT_NO_THROW(option = cpet::Option{options_file});
 
-  EXPECT_TRUE(option.centerID.isConstant());
-  EXPECT_EQ(option.centerID, cpet::AtomID::Constants::origin);
+  EXPECT_TRUE(option.centerID().isConstant());
+  EXPECT_EQ(option.centerID(), cpet::AtomID::Constants::origin);
 
-  EXPECT_TRUE(option.direction1ID.isConstant());
-  EXPECT_EQ(option.direction1ID, cpet::AtomID::Constants::e1);
+  EXPECT_TRUE(option.direction1ID().isConstant());
+  EXPECT_EQ(option.direction1ID(), cpet::AtomID::Constants::e1);
 
-  EXPECT_TRUE(option.direction2ID.isConstant());
-  EXPECT_EQ(option.direction2ID, cpet::AtomID::Constants::e2);
+  EXPECT_TRUE(option.direction2ID().isConstant());
+  EXPECT_EQ(option.direction2ID(), cpet::AtomID::Constants::e2);
 
   EXPECT_TRUE(option.calculateFieldLocations().empty());
   EXPECT_TRUE(option.calculateEFieldVolumes().empty());
 
   ASSERT_EQ(option.calculateEFieldTopology().size(), 1);
-  auto tr1 = &option.calculateEFieldTopology()[0];
+  const auto *tr1 = &option.calculateEFieldTopology()[0];
 
   EXPECT_EQ(tr1->numberOfSamples, 10);
   EXPECT_EQ(tr1->volume->type(), "box");
@@ -141,20 +141,20 @@ TEST(Option, ValidTopoBoxAlign) {
   cpet::Option option;
   ASSERT_NO_THROW(option = cpet::Option{options_file});
 
-  EXPECT_FALSE(option.centerID.isConstant());
-  EXPECT_EQ(option.centerID, "D:45:CG");
+  EXPECT_FALSE(option.centerID().isConstant());
+  EXPECT_EQ(option.centerID(), "D:45:CG");
 
-  EXPECT_TRUE(option.direction1ID.isConstant());
-  EXPECT_EQ(option.direction1ID, cpet::AtomID::Constants::e1);
+  EXPECT_TRUE(option.direction1ID().isConstant());
+  EXPECT_EQ(option.direction1ID(), cpet::AtomID::Constants::e1);
 
-  EXPECT_TRUE(option.direction2ID.isConstant());
-  EXPECT_EQ(option.direction2ID, cpet::AtomID::Constants::e2);
+  EXPECT_TRUE(option.direction2ID().isConstant());
+  EXPECT_EQ(option.direction2ID(), cpet::AtomID::Constants::e2);
 
   EXPECT_TRUE(option.calculateFieldLocations().empty());
   EXPECT_TRUE(option.calculateEFieldVolumes().empty());
 
   ASSERT_EQ(option.calculateEFieldTopology().size(), 1);
-  auto tr1 = &option.calculateEFieldTopology()[0];
+  const auto *tr1 = &option.calculateEFieldTopology()[0];
 
   EXPECT_EQ(tr1->numberOfSamples, 100000);
   EXPECT_EQ(tr1->volume->type(), "box");

--- a/tests/test_pointcharges.cpp
+++ b/tests/test_pointcharges.cpp
@@ -9,6 +9,7 @@
 #include "AtomID.h"
 #include "Exceptions.h"
 #include "PointCharge.h"
+#include "Frame.h"
 
 TEST(AtomID, GenerateFromPDB) {
   const std::vector<std::string> pdbLines = {
@@ -171,15 +172,15 @@ TEST(PointCharge, find) {
   cpet::PointCharge pc4{Eigen::Vector3d{4.23, 8.0, -2.5}, 1.0,
                         cpet::AtomID{"B:200:HB"}};
 
-  std::vector<cpet::PointCharge> system = {pc1, pc2, pc3, pc4};
+  cpet::Frame system({pc1, pc2, pc3, pc4});
 
-  EXPECT_EQ(*cpet::PointCharge::find(system, cpet::AtomID{"C:35:SG\'"}), pc2);
-  EXPECT_EQ(*cpet::PointCharge::find(system, cpet::AtomID{"A:4:CD"}), pc1);
-  EXPECT_EQ(*cpet::PointCharge::find(system, cpet::AtomID{"B:200:HB"}), pc4);
+  EXPECT_EQ(*system.find(cpet::AtomID{"C:35:SG\'"}), pc2);
+  EXPECT_EQ(*system.find(cpet::AtomID{"A:4:CD"}), pc1);
+  EXPECT_EQ(*system.find(cpet::AtomID{"B:200:HB"}), pc4);
 
-  EXPECT_THROW((void)cpet::PointCharge::find(system, cpet::AtomID("C:35:SG")),
+  EXPECT_THROW((void)system.find(cpet::AtomID("C:35:SG")),
                cpet::value_not_found);
-  EXPECT_THROW((void)cpet::PointCharge::find(system, cpet::AtomID("D:54:C102")),
+  EXPECT_THROW((void)system.find(cpet::AtomID("D:54:C102")),
                cpet::value_not_found);
 }
 

--- a/tests/test_system.cpp
+++ b/tests/test_system.cpp
@@ -33,7 +33,7 @@ TEST(System, SimpleField) {
     EXPECT_NEAR((field - expected_result).norm(), 0, 0.00001);
   }
 
-  option.centerID = cpet::AtomID("1:1:1");
+  option.centerID("1:1:1");
 
   {
     cpet::System sys{pc, option};

--- a/tests/test_system.cpp
+++ b/tests/test_system.cpp
@@ -25,8 +25,8 @@ TEST(System, SimpleField) {
 
     EXPECT_EQ(sys.basisMatrix(), identity);
 
-    Eigen::Vector3d field =
-        sys.electricFieldAt(*option.calculateFieldLocations()[0].locations()[0].position());
+    Eigen::Vector3d field = sys.electricFieldAt(
+        *option.calculateFieldLocations()[0].locations()[0].position());
 
     Eigen::Vector3d expected_result{2.77121, 2.77121, 2.77121};
 
@@ -44,8 +44,8 @@ TEST(System, SimpleField) {
     Eigen::Matrix3d identity = Eigen::Matrix3d::Identity();
     EXPECT_EQ(sys.basisMatrix(), identity);
 
-    Eigen::Vector3d loc =
-        sys.transformToUserSpace(*option.calculateFieldLocations()[0].locations()[0].position());
+    Eigen::Vector3d loc = sys.transformToUserSpace(
+        *option.calculateFieldLocations()[0].locations()[0].position());
 
     Eigen::Vector3d field = sys.electricFieldAt(loc);
     Eigen::Vector3d expected_result{2.77121, 2.77121, 2.77121};

--- a/tests/test_system.cpp
+++ b/tests/test_system.cpp
@@ -8,10 +8,12 @@
 #include "Option.h"
 #include "System.h"
 #include "PointCharge.h"
+#include "FieldLocations.h"
 
 TEST(System, SimpleField) {
   cpet::Option option;
-  option.calculateEFieldPoints.push_back(cpet::AtomID("1:1:1"));
+
+  option.addFieldLocations(cpet::FieldLocations::fromSimple({"1:1:1"}));
 
   std::vector<cpet::PointCharge> pc;
   pc.emplace_back(Eigen::Vector3d{0, 0, 0}, 1, cpet::AtomID{"A:1:NH"});
@@ -24,7 +26,7 @@ TEST(System, SimpleField) {
     EXPECT_EQ(sys.basisMatrix(), identity);
 
     Eigen::Vector3d field =
-        sys.electricFieldAt(*option.calculateEFieldPoints[0].position());
+        sys.electricFieldAt(*option.calculateFieldLocations()[0].locations()[0].position());
 
     Eigen::Vector3d expected_result{2.77121, 2.77121, 2.77121};
 
@@ -43,7 +45,7 @@ TEST(System, SimpleField) {
     EXPECT_EQ(sys.basisMatrix(), identity);
 
     Eigen::Vector3d loc =
-        sys.transformToUserSpace(*option.calculateEFieldPoints[0].position());
+        sys.transformToUserSpace(*option.calculateFieldLocations()[0].locations()[0].position());
 
     Eigen::Vector3d field = sys.electricFieldAt(loc);
     Eigen::Vector3d expected_result{2.77121, 2.77121, 2.77121};

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -209,3 +209,13 @@ TEST(startswith, EmptyString) {
 
   EXPECT_TRUE(cpet::util::startswith("", ""));
 }
+
+TEST(countSetBits, UnsignedInt) {
+  unsigned int a = 2;
+  EXPECT_EQ(cpet::util::countSetBits(a), 1);
+  a = 3;
+  EXPECT_EQ(cpet::util::countSetBits(a), 2);
+  a = 10;
+  EXPECT_EQ(cpet::util::countSetBits(a), 2);
+
+}

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -218,3 +218,17 @@ TEST(countSetBits, UnsignedInt) {
   a = 10;
   EXPECT_EQ(cpet::util::countSetBits(a), 2);
 }
+TEST(tolower, standard) {
+  std::string str = "THIS IS A CAPITAL STRING";
+
+  EXPECT_EQ(cpet::util::tolower(str), "this is a capital string");
+  str = "let's TRY another String!!!";
+  EXPECT_EQ(cpet::util::tolower(str), "let's try another string!!!");
+
+  EXPECT_EQ(cpet::util::tolower("HOW ABOUT THIS ONE?!?!!?!?!?!!"), "how about this one?!?!!?!?!?!!");
+}
+
+TEST(tolower, substrings) {
+  std::string str = "LETS' try THIS 1 chumpsss";
+  EXPECT_EQ(cpet::util::tolower(str.substr(0,4)), "lets");
+}

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -225,10 +225,11 @@ TEST(tolower, standard) {
   str = "let's TRY another String!!!";
   EXPECT_EQ(cpet::util::tolower(str), "let's try another string!!!");
 
-  EXPECT_EQ(cpet::util::tolower("HOW ABOUT THIS ONE?!?!!?!?!?!!"), "how about this one?!?!!?!?!?!!");
+  EXPECT_EQ(cpet::util::tolower("HOW ABOUT THIS ONE?!?!!?!?!?!!"),
+            "how about this one?!?!!?!?!?!!");
 }
 
 TEST(tolower, substrings) {
   std::string str = "LETS' try THIS 1 chumpsss";
-  EXPECT_EQ(cpet::util::tolower(str.substr(0,4)), "lets");
+  EXPECT_EQ(cpet::util::tolower(str.substr(0, 4)), "lets");
 }

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -217,5 +217,4 @@ TEST(countSetBits, UnsignedInt) {
   EXPECT_EQ(cpet::util::countSetBits(a), 2);
   a = 10;
   EXPECT_EQ(cpet::util::countSetBits(a), 2);
-
 }


### PR DESCRIPTION
Add the ability to plot x, y, z, and magnitude when using the %field command.
Changes default output for simple field command to not. Slowly overriding the -O option as a command line argument, which will be completely removed in the eventual version 1.0.0